### PR TITLE
Alterado `PHP Binding Classes` para arrumar alguns erros de parse e para tratar melhor os erros da API 

### DIFF
--- a/lib/NFe/APIRequest.php
+++ b/lib/NFe/APIRequest.php
@@ -40,6 +40,10 @@ class NFe_APIRequest {
       }
     }
 
+    if ( $response_code == 403 ) {
+      throw new NFeAuthorizationException($response_body);
+    }
+
     if ( $response_code == 409 ) {
       throw new NFeObjectAlreadyExists($response_body);
     }

--- a/lib/NFe/APIRequest.php
+++ b/lib/NFe/APIRequest.php
@@ -28,19 +28,28 @@ class NFe_APIRequest {
     $headers = $this->_defaultHeaders();
 
     list( $response_body, $response_code ) = $this->requestWithCURL( $method, $url, $headers, $data );
+    $response = json_encode("{}");
+
     if ( $response_code == 302 ) {
       $response = $response_body;
     }
-    else {
+    else if (!empty($response_body)) {
       $response = json_decode($response_body);
+      if ( json_last_error() != JSON_ERROR_NONE ) {
+        throw new NFeInvalidResponseBody($response_body);
+      }
     }
 
-    if ( json_last_error() != JSON_ERROR_NONE ) {
-      throw new NFeObjectNotFound($response_body);
+    if ( $response_code == 409 ) {
+      throw new NFeObjectAlreadyExists($response_body);
     }
 
     if ( $response_code == 404 ) {
       throw new NFeObjectNotFound($response_body);
+    }
+
+    if ( $response_code == 400 ) {
+      throw new NFeException($response->message);
     }
 
     if ( isset($response->errors) ) {

--- a/lib/NFe/APIResource.php
+++ b/lib/NFe/APIResource.php
@@ -109,7 +109,7 @@ class NFe_APIResource extends NFe_Object {
 
   protected static function fetchAPI($key) {
     try {
-      $response = self::API()->request( 'GET', static::url($key) );
+        $response = self::API()->request( 'GET', static::url($key) );
       return self::createFromResponse($response);
     }
     catch ( NFeObjectNotFound $e ) {

--- a/lib/NFe/APIResource.php
+++ b/lib/NFe/APIResource.php
@@ -39,22 +39,30 @@ class NFe_APIResource extends NFe_Object {
 
   public static function endpointAPI( $object = null, $uri_path = '' ) {
     $path = '';
+    $resource = self::objectBaseURI();
 
     if ( is_string($object) || is_integer($object) ) {
       $path = '/' . $object;
     }
     elseif (is_array($object) && isset($object['company_id'])) {
-      $uri_path = '/companies/' . $object['company_id'];
+        $uri_path = '/companies/' . $object['company_id'];
+
+        if (isset($object['id'])) {
+            $path = '/' . $object['id'];
+        }
     }
-    elseif (is_object($object) && isset($object->provider) && isset($object->provider->id) ) {
-      $uri_path = '/companies/' . $object->provider->id;
+    elseif (is_object($object)) {
+        if (isset($object->provider) && isset($object->provider->id)) {
+            $uri_path = '/companies/' . $object->provider->id;
+        }
+
+        if (!$object->is_new()) {
+            $path = '/' . $object->id;
+        }
     }
 
-    if (isset($object['id'])) {
-      $path = '/' . $object['id'];
-    }
 
-    return strtolower( NFe::getBaseURI() . $uri_path . '/' . self::objectBaseURI() . $path );
+    return strtolower( NFe::getBaseURI() . $uri_path . '/' .  $resource . $path );
   }
 
   public static function url( $object = null ) {
@@ -74,7 +82,6 @@ class NFe_APIResource extends NFe_Object {
     // if ( $this['id'] == null ) { // $this['id']
       // return false;
     // }
-
     try {
       $response = self::API()->request( 'DELETE', static::url($this) );
 

--- a/lib/NFe/Company.php
+++ b/lib/NFe/Company.php
@@ -6,22 +6,22 @@ class NFe_Company extends NFe_APIResource {
   }
 
   public static function fetch($key) {
-  	return self::fetchAPI($key); 
+  	return self::fetchAPI($key);
   }
 
-  public function save() { 
+  public function save() {
   	return $this->saveAPI();
   }
 
-  public function delete() { 
-  	return $this->deleteAPI(); 
+  public function delete() {
+  	return $this->deleteAPI();
   }
 
-  public function refresh() { 
-  	return $this->refreshAPI(); 
+  public function refresh() {
+  	return $this->refreshAPI();
   }
 
-  public static function search( $options = array() ) { 
-  	return self::searchAPI($options); 
+  public static function search( $options = array() ) {
+  	return self::searchAPI($options);
   }
 }

--- a/lib/NFe/Error.php
+++ b/lib/NFe/Error.php
@@ -1,6 +1,7 @@
 <?php
 
 class NFeAuthenticationException extends NFeException {}
+class NFeAuthorizationException extends NFeException {}
 class NFeObjectNotFound extends NFeException {}
 class NFeException extends Exception {}
 class NFeObjectAlreadyExists extends NFeException {}

--- a/lib/NFe/Error.php
+++ b/lib/NFe/Error.php
@@ -1,5 +1,7 @@
 <?php
 
-class NFeAuthenticationException extends Exception {}
-class NFeObjectNotFound extends Exception {}
+class NFeAuthenticationException extends NFeException {}
+class NFeObjectNotFound extends NFeException {}
 class NFeException extends Exception {}
+class NFeObjectAlreadyExists extends NFeException {}
+class NFeInvalidResponseBody extends NFeException {}

--- a/lib/NFe/Object.php
+++ b/lib/NFe/Object.php
@@ -2,7 +2,7 @@
 
 /**
  * NFe_Object manages the Object State
- * 
+ *
  * Values that changed, values that need to be saved
  */
 class NFe_Object implements arrayAccess {

--- a/lib/NFe/Utilities.php
+++ b/lib/NFe/Utilities.php
@@ -89,9 +89,18 @@ class NFe_Utilities {
       return new NFe_SearchResult( $results, count($results) );
     }
     elseif ( is_object($response) ) {
-        $resource = $class_name::objectBaseURI();
-        if(isset($response->$resource)) {
-            return new $class_name( (array) $response->$resource );
+        $resources = $class_name::objectBaseURI();
+        if(isset($response->$resources)) {
+            $result = [];
+            if (is_array($response->$resources)) {
+                foreach($response->$resources as $resource) {
+                    $result[] = new $class_name( (array) $resource );
+                }
+
+                return $result;
+            }
+
+            return new $class_name( (array) $response->$resources );
         }
         return new $class_name( (array) $response );
     }

--- a/lib/NFe/Utilities.php
+++ b/lib/NFe/Utilities.php
@@ -30,7 +30,7 @@ class NFe_Utilities {
   }
 
   public static function arrayToParamsUrl($array, $prefix = null) {
-    if ( !is_array($array) ) { 
+    if ( !is_array($array) ) {
       return $array;
     }
 
@@ -89,9 +89,12 @@ class NFe_Utilities {
       return new NFe_SearchResult( $results, count($results) );
     }
     elseif ( is_object($response) ) {
-      return new $class_name( (array) $response );
+        $resource = $class_name::objectBaseURI();
+        if(isset($response->$resource)) {
+            return new $class_name( (array) $response->$resource );
+        }
+        return new $class_name( (array) $response );
     }
-
     return null;
   }
 }

--- a/test/NFe/CompanyTest.php
+++ b/test/NFe/CompanyTest.php
@@ -5,7 +5,7 @@ class NFe_CompanyTest extends NFe_TestCase {
 
   public function testCreateAndDelete() {
     $attributes = array(
-      'federalTaxNumber' => 48527553000123, // Generate CNPJ here: http://www.geradordecnpj.org/
+      'federalTaxNumber' => 97625117000100, // Generate CNPJ here: http://www.geradordecnpj.org/
       'name'             => 'TEST Company Name',
       'tradeName'        => 'Company Name',
       'email'            => 'nfe@mailinator.com',
@@ -28,38 +28,37 @@ class NFe_CompanyTest extends NFe_TestCase {
     $object = NFe_Company::create( $attributes );
 
     $this->assertNotNull($object);
-    $this->assertNotNull( $object->companies->name );
-    $this->assertEqual( $object->companies->name, 'TEST Company Name' );
-
-    self::$id = $object->companies->id;
+    $this->assertNotNull( $object->name );
+    $this->assertEqual( $object->name, 'TEST Company Name' );
+    self::$id = $object->id;
   }
 
   public function testGet() {
     $object = NFe_Company::fetch( self::$id );
 
     $this->assertNotNull($object);
-    $this->assertNotNull($object->companies->name);
-    $this->assertEqual($object->companies->name, 'TEST Company Name');
+    $this->assertNotNull($object->name);
+    $this->assertEqual($object->name, 'TEST Company Name');
   }
 
   public function testUpdate() {
     $object = NFe_Company::fetch( self::$id );
 
-    $object->companies->name = 'BB SA';
+    $object->name = 'BB SA';
 
     // @todo Check it out why this is giving error
-    // $this->assertTrue( $object->save() ); 
+    // $this->assertTrue( $object->save() );
 
     $this->assertNotNull($object);
-    $this->assertNotNull($object->companies->name);
-    $this->assertEqual($object->companies->name, 'BB SA');
+    $this->assertNotNull($object->name);
+    $this->assertEqual($object->name, 'BB SA');
   }
 
   public function testDelete() {
     $object = NFe_Company::fetch( self::$id );
 
     $this->assertNotNull($object);
-    $this->assertNotNull($object->companies->name);
+    $this->assertNotNull($object->name);
     $this->assertTrue( $object->delete() );
   }
 }

--- a/test/NFe/LegalPersonTest.php
+++ b/test/NFe/LegalPersonTest.php
@@ -13,7 +13,6 @@ class NFe_LegalPersonTest extends NFe_TestCase {
     $this->expectException('NFeObjectNotFound');
 
     $result = NFe_LegalPerson::fetch( self::$company_id, self::$company_id );
-
     $this->assertNull($result);
   }
 

--- a/test/NFe/ServiceInvoiceTest.php
+++ b/test/NFe/ServiceInvoiceTest.php
@@ -7,7 +7,7 @@ class NFe_ServiceInvoiceTest extends NFe_TestCase {
   public function testIssue() {
     $this->invoice = NFe_ServiceInvoice::create(
       // ID da empresa, você deve copiar exatamente como está no painel
-      "58ab266128718d082845e4be",
+      "54244e0ee340420fdc94ad09",
 
       // Dados da nota fiscal de serviço
       array(
@@ -63,7 +63,7 @@ class NFe_ServiceInvoiceTest extends NFe_TestCase {
     public function testFetchInvoice() {
 
     $fetched_invoice = NFe_ServiceInvoice::fetch(
-      "58ab266128718d082845e4be",
+      "54244e0ee340420fdc94ad09",
       $this->invoice->id
     );
 
@@ -75,7 +75,7 @@ class NFe_ServiceInvoiceTest extends NFe_TestCase {
 
   public function testDownloadPdfInvoice() {
     $url = NFe_ServiceInvoice::pdf(
-      "58ab266128718d082845e4be",
+      "54244e0ee340420fdc94ad09",
       $this->invoice->id
     );
 
@@ -84,7 +84,7 @@ class NFe_ServiceInvoiceTest extends NFe_TestCase {
 
   public function testDownloadXmlInvoice() {
     $url = NFe_ServiceInvoice::xml(
-      "58ab266128718d082845e4be",
+      "54244e0ee340420fdc94ad09",
       $this->invoice->id
     );
 
@@ -93,7 +93,7 @@ class NFe_ServiceInvoiceTest extends NFe_TestCase {
 
   public function testCancelInvoice() {
     $fetched_invoice = NFe_ServiceInvoice::fetch(
-      "58ab266128718d082845e4be",
+      "54244e0ee340420fdc94ad09",
       $this->invoice->id
     );
 

--- a/test/NFe/ServiceInvoiceTest.php
+++ b/test/NFe/ServiceInvoiceTest.php
@@ -2,10 +2,12 @@
 
 class NFe_ServiceInvoiceTest extends NFe_TestCase {
 
+    protected $invoice;
+
   public function testIssue() {
     $this->invoice = NFe_ServiceInvoice::create(
       // ID da empresa, você deve copiar exatamente como está no painel
-      "54244e0ee340420fdc94ad09",
+      "58ab266128718d082845e4be",
 
       // Dados da nota fiscal de serviço
       array(
@@ -58,9 +60,10 @@ class NFe_ServiceInvoiceTest extends NFe_TestCase {
     $this->assertEqual($this->invoice->cityServiceCode, '2690');
   }
 
-  public function testFetchInvoice() {
+    public function testFetchInvoice() {
+
     $fetched_invoice = NFe_ServiceInvoice::fetch(
-      "54244e0ee340420fdc94ad09",
+      "58ab266128718d082845e4be",
       $this->invoice->id
     );
 
@@ -72,16 +75,16 @@ class NFe_ServiceInvoiceTest extends NFe_TestCase {
 
   public function testDownloadPdfInvoice() {
     $url = NFe_ServiceInvoice::pdf(
-      "54244e0ee340420fdc94ad09",
+      "58ab266128718d082845e4be",
       $this->invoice->id
     );
-    
+
     $this->assertTrue( strpos($url, "pdf") );
   }
 
   public function testDownloadXmlInvoice() {
     $url = NFe_ServiceInvoice::xml(
-      "54244e0ee340420fdc94ad09",
+      "58ab266128718d082845e4be",
       $this->invoice->id
     );
 
@@ -90,7 +93,7 @@ class NFe_ServiceInvoiceTest extends NFe_TestCase {
 
   public function testCancelInvoice() {
     $fetched_invoice = NFe_ServiceInvoice::fetch(
-      "54244e0ee340420fdc94ad09",
+      "58ab266128718d082845e4be",
       $this->invoice->id
     );
 

--- a/test/NFe/WebhookTest.php
+++ b/test/NFe/WebhookTest.php
@@ -16,37 +16,37 @@ class NFe_WebhookTest extends NFe_TestCase {
     $object = NFe_Webhook::create( $attributes );
 
     $this->assertNotNull($object);
-    $this->assertNotNull($object->hooks->url);
-    $this->assertEqual($object->hooks->url, $attributes['url']);
+    $this->assertNotNull($object->url);
+    $this->assertEqual($object->url, $attributes['url']);
 
-    self::$id = $object->hooks->id;
+    self::$id = $object->id;
   }
 
   public function testGet() {
     $object = NFe_Webhook::fetch( self::$id );
 
     $this->assertNotNull( $object );
-    $this->assertNotNull( $object['hooks'][0]->url );
-    $this->assertEqual( $object['hooks'][0]->url, 'http://google.com/test' );
+    $this->assertNotNull( $object->url );
+    $this->assertEqual( $object->url, 'http://google.com/test' );
   }
 
   public function testUpdate() {
     $object = NFe_Webhook::fetch( self::$id );
 
     $new_url = 'http://google.com/test2';
-    $object->hooks->url = $new_url;
+    $object->url = $new_url;
 
     $this->assertTrue($object->save());
     $this->assertNotNull($object);
-    $this->assertNotNull($object->hooks->url);
-    $this->assertEqual($object->hooks->url, $new_url);
+    $this->assertNotNull($object->url);
+    $this->assertEqual($object->url, $new_url);
   }
 
   public function testDelete() {
     $object = NFe_Webhook::fetch( self::$id );
 
     $this->assertNotNull($object);
-    $this->assertNotNull( $object->hooks->url );
+    $this->assertNotNull( $object->url );
     $this->assertTrue($object->delete());
   }
 
@@ -54,6 +54,5 @@ class NFe_WebhookTest extends NFe_TestCase {
     $hooks = NFe_Webhook::search();
 
     $this->assertNotNull( $hooks );
-    $this->assertNotNull( $hooks->hooks );
   }
 }


### PR DESCRIPTION

### Atenção: Eu ainda não terminei de testar as alterações feitas nessa pull request. Não fazer o merge ainda. Criei a pull request para compartilhar o trabalho com vocês.

# Motivo da Pull Request

Ao tentar usar a biblioteca PHP, tive diversos problemas como erros de parse de json , modelos de objetos fora do padrão do contrato da API da Nfe.io, .... Além disso, muitos erros na comunicação com a API (HTTP 409, HTTP 400, ...) eram camuflados e ignorados na biblioteca, dando um falso positivo de que tudo ocorreu bem para quem usava a mesma.

Abaixo segue a lista das alterações feitas na biblioteca.

Peço para que analisem, e se fizer sentido, façam o merge da full request para que futuros usuários não tenham os mesmo problemas que eu tive.

## Allterações

- Correção de leitura do body da response em APIRequest
- Melhoria nos tratamentos de erros da API em `APIRequest`
- Correção na construção das binding classes em `APIResource`
- Criação de novos `exceptions`
- Correção do parser da resposta da API em `Utilities`


# Outras Melhorias

A biblioteca está um pouco defasada em termos de arquitetura de código. Não segue PSR e a arquitetura poderia estar melhor desenhada.

Esta pull request não tem como objetivo atacar estes pontos de melhoria.
