### PR TITLE
docs(readme): banner apontando para a branch v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # Cliente PHP para emissão de notas fiscais - NFe.io
 
+> ⚠️ **Esta branch (`master`) está congelada na v2.5.** Não recebe novas
+> atualizações nem correções. Para integrações novas, use a **v3** —
+> reescrita moderna em PHP 8.2+, paridade com o SDK Node.js, zero
+> dependências em runtime:
+>
+> ```bash
+> composer require nfe/client-php
+> ```
+>
+> Acesse a [branch v3](https://github.com/nfe/client-php/tree/v3) para
+> o código atualizado, [README pt-BR](https://github.com/nfe/client-php/blob/v3/README.md),
+> [guia de migração v2 → v3](https://github.com/nfe/client-php/blob/v3/MIGRATION.md)
+> e exemplos runnable em [`samples/`](https://github.com/nfe/client-php/tree/v3/samples).
+>
+> O conteúdo abaixo descreve a v2 legada, mantido para integrações antigas.
+
+---
+
 ## Onde acessar a documentação da API?
 
 > Acesse a [nossa documentação](https://nfe.io/doc/rest-api/nfe-v1) para mais detalhes e referências.


### PR DESCRIPTION
## Resumo

Adiciona um banner curto no topo do `README.md` da branch `master` (v2.5, congelada) apontando para a branch `v3` — a reescrita moderna em PHP 8.2+ com paridade Node SDK.

## Motivação

Qualquer integrador que aterrissa hoje em `master` instala `nfe/nfe` (v2.5, sem novas atualizações) sem saber que a v3 existe. Banner é o caminho zero-fricção para redirecionar.

## Mudanças

- 18 linhas adicionadas no topo do `README.md`.
- Links para: branch v3, README pt-BR, MIGRATION.md, samples/.
- Conteúdo legado v2 mantido integralmente abaixo do banner.
- **Zero mudanças de código.**

## Test plan

- [ ] Visualizar o README renderizado na branch após merge — banner aparece no topo, conteúdo v2 intacto.
- [ ] Links do banner abrem `tree/v3`, `blob/v3/README.md`, `blob/v3/MIGRATION.md`, `tree/v3/samples`.