### PR TITLE
docs: adiciona guias completos em docs/ com cookbook por recurso

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,81 @@
+---
+title: Biblioteca NFE.io em PHP para Emissão de Notas Fiscais (NFS-e, NF-e, NFC-e, CT-e)
+description: SDK PHP oficial da NFE.io — PHP 8.2+, zero dependências de runtime, cliente único com recursos tipados e retorno discriminado por union types nativos.
+sidebar_label: Biblioteca PHP
+slug: /desenvolvedores/bibliotecas/php
+provider: NFE.io
+badge: SDK
+layout_type: IntegrationLayout
+heroImage: /docs/img/bibliotecas/php.svg
+ctaLabel: GitHub NFE.io PHP
+ctaUrl: https://github.com/nfe/client-php
+---
+
+# Biblioteca PHP NFE.io
+
+SDK oficial da [NFE.io](https://nfe.io) para PHP: emissão e gestão de documentos
+fiscais eletrônicos brasileiros (NFS-e, NF-e, NFC-e, CT-e) com PHP moderno e
+**zero dependências de runtime**.
+
+- **Cliente único** `Nfe\Client` com acessores `camelCase` por recurso, em
+  propriedades `public readonly`.
+- **PHP 8.2+ estrito** — `readonly`, enums, argumentos nomeados e **union types
+  nativos** para o retorno discriminado da emissão assíncrona.
+- **Paridade 1:1** com o [SDK Node.js](https://github.com/nfe/client-nodejs) —
+  mesmos recursos, mesmos hosts, mesmos payloads.
+
+## Requisitos
+
+- PHP **8.2**, **8.3** ou **8.4**.
+- Extensões: `ext-curl`, `ext-json`, `ext-mbstring`.
+- **Zero dependências de runtime** — cURL nativo; PSR-3 (log) e PSR-18
+  (transporte HTTP) são opcionais.
+
+## Instalação
+
+```sh
+composer require "nfe/nfe:^3.0"
+```
+
+## Primeiros passos
+
+```php
+use Nfe\Client;
+
+$nfe = new Client(apiKey: $_ENV['NFE_API_KEY']);
+
+$result = $nfe->serviceInvoices->create('55df4dc6b6cd9007e4f13ee8', [
+    'cityServiceCode' => '2690',
+    'description'     => 'Manutenção e suporte técnico',
+    'servicesAmount'  => 100.0,
+    'borrower'        => [
+        'federalTaxNumber' => 191,
+        'name'             => 'Banco do Brasil SA',
+    ],
+]);
+```
+
+O fluxo completo (retorno discriminado + polling) está em
+[Primeiros passos](./getting-started.md).
+
+## Guias
+
+| Guia | Conteúdo |
+|---|---|
+| [Primeiros passos](./getting-started.md) | Instalação, cliente, primeira emissão e polling. |
+| [Configuração](./configuration.md) | Argumentos do cliente, `Nfe\Config`, modelo de duas chaves, retry e transportes. |
+| [Emissão assíncrona e polling](./async-and-polling.md) | Contrato 202 `Pending`/`Issued` e o laço de polling com `FlowStatus`. |
+| [Tratamento de erros](./errors.md) | Hierarquia `Nfe\Exception\*` e padrões de `catch`. |
+| [Webhooks](./webhooks.md) | Verificação HMAC-SHA1 com `Nfe\Webhook` e idempotência/replay. |
+| [Paginação](./pagination.md) | Estilos page e cursor; `ListResponse` e `ListPage`. |
+| [Downloads](./downloads.md) | PDF/XML como bytes em `string`. |
+| [Roteamento multi-host](./multi-host-routing.md) | Os hosts por família de recurso. |
+| [Cookbook por recurso](./recursos/) | Um exemplo por recurso (os 17 recursos do cliente). |
+
+## Migração
+
+Vindo da série `2.x` (`NFe_io`, prefixo `NFe_`)? Veja o
+[guia de migração](https://github.com/nfe/client-php/blob/master/MIGRATION.md) —
+a `v3.0` é uma reescrita completa, sem camada de compatibilidade. As linhas v2 e
+v3 compartilham o mesmo pacote Composer (`nfe/nfe`); o Composer resolve cada
+constraint (`^2.0` / `^3.0`) para a major correta automaticamente.

--- a/docs/_category_.json
+++ b/docs/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Biblioteca PHP",
+  "position": 5,
+  "collapsed": true
+}

--- a/docs/async-and-polling.md
+++ b/docs/async-and-polling.md
@@ -1,0 +1,149 @@
+---
+title: Emissão assíncrona e polling no SDK PHP da NFE.io
+sidebar_label: Assíncrono e polling
+sidebar_position: 3
+slug: emissao-assincrona-e-polling
+description: Entenda o contrato HTTP 202, os resultados Pending e Issued discriminados por union types nativos com instanceof, e como montar um loop de polling com FlowStatus::isTerminal().
+---
+
+# Emissão assíncrona e polling
+
+A emissão de documentos fiscais é, em geral, **assíncrona**: a API aceita a
+requisição (HTTP 202) e segue processando. Esta página explica o contrato de
+retorno, os dois tipos de resultado e como acompanhar o processamento até um
+estado terminal.
+
+## O contrato HTTP 202
+
+Quando a API responde **202 Accepted**, o documento ainda **não** foi
+materializado — ela apenas aceitou o pedido. Quando responde **201/200**, o
+documento já está pronto. O `create()` traduz isso em um **union type nativo do
+PHP**: um de dois tipos.
+
+| Resposta HTTP | Tipo de resultado | Significado |
+| --- | --- | --- |
+| 202 Accepted | `*Pending` | Em processamento; reconsulte depois. |
+| 201 / 200 | `*Issued` | Documento já materializado. |
+
+:::note `*Pending` e `*Issued` por recurso
+Cada recurso expõe seu par de resultados — por exemplo,
+`Nfe\Response\ServiceInvoicePending` e `Nfe\Response\ServiceInvoiceIssued` (o
+mesmo vale para `ProductInvoice*` e `ConsumerInvoice*`). Todos implementam as
+interfaces marcadoras `Nfe\Response\Pending` e `Nfe\Response\Issued`, que é
+contra o que você testa com `instanceof`.
+:::
+
+## Os dois tipos de resultado
+
+### `*Pending` (202)
+
+- `invoiceId()` — id extraído do último segmento do header `Location`; use-o
+  para reconsultar enquanto processa.
+- `location()` — o valor bruto do header `Location`.
+
+:::warning `Pending` não tem corpo de nota
+Um HTTP 202 não traz o documento — o objeto `Pending` carrega **apenas**
+`invoiceId()` e `location()`. Não é possível ler valores de imposto ou número da
+nota dele; busque com `retrieve()` depois que o processamento chegar a um estado
+terminal. Um 202 **sem** header `Location` lança
+`Nfe\Exception\InvalidRequestException`.
+:::
+
+### `*Issued` (201/200)
+
+- `resource()` — o documento já materializado (DTO hidratado).
+
+## Distinguindo o resultado
+
+Não há campo `status` nem métodos `pending?()`/`issued?()` — use `instanceof`:
+
+```php
+use Nfe\Response\Pending;
+
+$result = $nfe->serviceInvoices->create($companyId, [
+    'cityServiceCode' => '2690',
+    'servicesAmount'  => 100.0,
+    'description'     => 'Suporte',
+    'borrower'        => ['federalTaxNumber' => 191, 'name' => 'Banco do Brasil SA'],
+]);
+
+if ($result instanceof Pending) {
+    $invoiceId = $result->invoiceId();   // reconsulte com este id
+} else {
+    $invoice = $result->resource();      // NFS-e já pronta
+}
+```
+
+## Loop de polling manual
+
+Para NFS-e, faça polling com `getStatus()` (endpoint leve de status) até um
+**estado terminal**, decidido por `Nfe\Util\FlowStatus::isTerminal()`:
+
+```php
+use Nfe\Response\Pending;
+use Nfe\Util\FlowStatus;
+
+if ($result instanceof Pending) {
+    $invoiceId = $result->invoiceId();
+    $deadline  = time() + 300;           // defina seu próprio orçamento de tempo
+    $delay     = 1;
+
+    do {
+        sleep($delay);
+        $delay = min($delay * 2, 10);    // backoff próprio
+        $flow  = $nfe->serviceInvoices->getStatus($companyId, $invoiceId)['flowStatus'] ?? '';
+    } while (!FlowStatus::isTerminal($flow) && time() < $deadline);
+
+    if ($flow === 'Issued') {
+        $invoice = $nfe->serviceInvoices->retrieve($companyId, $invoiceId);
+    } else {
+        // 'IssueFailed' | 'Cancelled' | 'CancelFailed' — ou estourou o prazo
+    }
+}
+```
+
+### Estados de fluxo (`flowStatus`)
+
+Estados **terminais** (encerram o polling — `FlowStatus::TERMINAL`):
+
+| Status | Significado |
+| --- | --- |
+| `Issued` | Emitido com sucesso. |
+| `IssueFailed` | Falha na emissão. |
+| `Cancelled` | Cancelado. |
+| `CancelFailed` | Falha no cancelamento. |
+
+Estados **não terminais** (continue o polling): `WaitingSend`, `WaitingReturn`,
+`WaitingDownload`, `WaitingCalculateTaxes`, `WaitingDefineRpsNumber`,
+`WaitingSendCancel`, `PullFromCityHall`.
+
+:::warning Terminal ≠ sucesso
+`FlowStatus::isTerminal()` retorna `true` para **sucesso e falha**. Sempre
+compare o status concreto (`=== 'Issued'`) antes de considerar a nota emitida.
+:::
+
+:::note `getStatus()` só existe em `serviceInvoices`
+Para `productInvoices` e `consumerInvoices` não há `getStatus()` — faça polling
+com `retrieve()` e leia o campo de fluxo do DTO. Mas a emissão de NF-e/NFC-e é
+**orientada a webhook**: prefira [Webhooks](./webhooks.md) a polling nesses
+recursos.
+:::
+
+## Por que não existe `createAndWait`?
+
+A `v3.0` **não** implementa `createAndWait()`, `pollUntilComplete()` nem
+qualquer helper de espera. O contrato discriminado `*Pending`/`*Issued` somado a
+`FlowStatus::isTerminal()` é suficiente para escrever loops de polling manuais,
+e esses auxiliares ficam deliberadamente adiados para uma versão futura — sem
+quebrar o contrato público.
+
+:::warning Não chame helpers inexistentes
+Referenciar `$nfe->serviceInvoices->createAndWait(...)` na `v3.0` gera um erro
+fatal (`Call to undefined method`), pois o método não está definido.
+:::
+
+## Próximos passos
+
+- [Tratamento de erros](./errors.md) — trate falhas durante o polling.
+- [Webhooks](./webhooks.md) — receba a conclusão por push em vez de polling.
+- [Primeiros passos](./getting-started.md) — a primeira emissão de ponta a ponta.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,193 @@
+---
+title: Configuração do cliente do SDK PHP da NFE.io
+sidebar_label: Configuração
+sidebar_position: 2
+slug: configuracao
+description: Todas as opções do Nfe\Client e do Nfe\Config — chaves de API, modelo de duas chaves, timeout, retry, logger PSR-3, transporte PSR-18 e overrides por requisição.
+---
+
+# Configuração
+
+Esta página descreve como configurar o `Nfe\Client`: os argumentos de
+conveniência do construtor, as opções avançadas que vivem em `Nfe\Config`, o
+modelo de duas chaves, a política de retry e os overrides por requisição com
+`Nfe\Http\RequestOptions`.
+
+## Argumentos de `new Nfe\Client(...)`
+
+O construtor aceita **argumentos nomeados**:
+
+```php
+use Nfe\Client;
+use Nfe\Environment;
+
+$nfe = new Client(
+    apiKey: $_ENV['NFE_API_KEY'],
+    dataApiKey: $_ENV['NFE_DATA_API_KEY'] ?? null,
+    environment: Environment::Production,
+    timeout: 60,
+    userAgentSuffix: 'meu-integrador/1.0',
+);
+```
+
+| Argumento | Tipo | Padrão | Descrição |
+| --- | --- | --- | --- |
+| `apiKey` | `?string` | `null` | Chave principal. Obrigatória quando `config` não é informado. |
+| `dataApiKey` | `?string` | `null` | Chave dos serviços de dados (CEP/CNPJ/CPF/consultas). Fallback para `apiKey`. |
+| `config` | `?Nfe\Config` | `null` | Quando informado, **os demais argumentos de conveniência são ignorados**. |
+| `environment` | `Nfe\Environment` | `Environment::Production` | `Production` ou `Sandbox`. Reservado para uso futuro (sem efeito sobre os endpoints hoje). |
+| `timeout` | `int` | `60` | Timeout por requisição, em segundos (deve ser positivo). |
+| `transport` | `?Nfe\Http\Transport` | `null` | Transporte HTTP customizado (adaptador PSR-18, mock). `null` = cURL padrão. |
+| `userAgentSuffix` | `?string` | `null` | Sufixo anexado ao `User-Agent` do SDK. |
+
+:::note Validação na construção
+As opções são validadas na criação. `apiKey` vazia, `dataApiKey` vazia (quando
+não nula) ou `timeout` não positivo lançam `Nfe\Exception\InvalidRequestException`
+antes de qualquer requisição HTTP. Veja [Tratamento de erros](./errors.md).
+:::
+
+:::note Sem fallback por variáveis de ambiente
+O SDK **não** lê `NFE_API_KEY`/`NFE_DATA_API_KEY` automaticamente — resolva as
+variáveis você mesmo (`$_ENV`, `getenv()`, secrets do framework) e passe-as ao
+construtor.
+:::
+
+## Opções avançadas — somente em `Nfe\Config`
+
+Retry e logger **não** são aceitos diretamente por `new Client(...)`. Eles vivem
+em `Nfe\Config`, que é injetado via `config:` (e então substitui todos os
+argumentos de conveniência):
+
+```php
+use Nfe\Client;
+use Nfe\Config;
+use Nfe\Http\RetryPolicy;
+
+$nfe = new Client(config: new Config(
+    apiKey: $_ENV['NFE_API_KEY'],
+    dataApiKey: $_ENV['NFE_DATA_API_KEY'] ?? null,
+    timeout: 60,
+    retry: new RetryPolicy(maxRetries: 5, baseDelay: 0.5, maxDelay: 20.0, jitter: 0.3),
+    logger: $meuLoggerPsr3,           // Psr\Log\LoggerInterface (opcional)
+    userAgentSuffix: 'meu-integrador/1.0',
+));
+```
+
+| Opção | Tipo | Padrão | Descrição |
+| --- | --- | --- | --- |
+| `retry` | `Nfe\Http\RetryPolicy` | `new RetryPolicy()` | Política de retentativas (veja abaixo). |
+| `logger` | `?Psr\Log\LoggerInterface` | `null` | Logger PSR-3 opcional. O pacote `psr/log` **não** é exigido em runtime. |
+| `transport` | `?Nfe\Http\Transport` | `null` | Transporte HTTP customizado. |
+
+## Retry (`Nfe\Http\RetryPolicy`)
+
+O transporte retenta automaticamente respostas **HTTP 429** e **5xx** com
+backoff exponencial e jitter. O padrão é `maxRetries: 3`, `baseDelay: 1.0`s,
+`maxDelay: 30.0`s, `jitter: 0.3` (±30%). Erros 4xx de negócio **não** são
+retentados.
+
+```php
+use Nfe\Http\RetryPolicy;
+
+// Desabilitar completamente:
+$config = new Nfe\Config(apiKey: $key, retry: RetryPolicy::none());
+```
+
+## Modelo de duas chaves
+
+A plataforma separa a cobrança entre a API principal (emissão — cobrada por
+documento) e os serviços de **dados** (consultas — cobrados por consulta, muitas
+vezes em outro plano). As famílias de dados — `addresses` (CEP), `legal-entity`
+(CNPJ), `natural-person` (CPF) e `nfe-query` (consultas de NF-e/NFC-e) — usam a
+`dataApiKey` quando presente, com **fallback** para a `apiKey`. Todas as demais
+famílias usam a `apiKey`.
+
+```php
+$nfe = new Nfe\Client(
+    apiKey: 'chave-de-emissao',
+    dataApiKey: 'chave-de-consulta',
+);
+
+// - $nfe->addresses           → usa dataApiKey (família de dados)
+// - $nfe->legalEntityLookup   → usa dataApiKey
+// - $nfe->serviceInvoices     → usa apiKey (emissão)
+// - $nfe->companies           → usa apiKey
+```
+
+:::warning `api.nfse.io` usa a chave principal
+`taxCalculation`, `taxCodes`, `transportationInvoices` e
+`inboundProductInvoices` (host `api.nfse.io`) **não** são famílias de dados:
+sempre usam a `apiKey`. Um 403 nas famílias de dados com uma chave principal
+válida normalmente significa que o plano da chave não inclui o produto de
+dados — informe uma `dataApiKey` provisionada. Veja
+[Roteamento multi-host](./multi-host-routing.md).
+:::
+
+## Overrides por requisição (`Nfe\Http\RequestOptions`)
+
+Todo método de recurso aceita um `RequestOptions` opcional como último argumento
+para sobrescrever chave, host ou timeout **de uma única chamada** — útil em
+integrações multi-tenant:
+
+```php
+use Nfe\Http\RequestOptions;
+
+$invoice = $nfe->serviceInvoices->retrieve(
+    $companyId,
+    $invoiceId,
+    new RequestOptions(apiKey: $chaveDoTenant, timeout: 120),
+);
+```
+
+| Campo | Efeito |
+| --- | --- |
+| `apiKey` | Substitui a chave resolvida para esta chamada. |
+| `baseUrl` | Aponta a chamada para outro host (mock, proxy, ambiente próprio). |
+| `timeout` | Timeout específico desta chamada, em segundos. |
+
+:::note Sem `idempotencyKey`
+A API da NFE.io não honra o header `Idempotency-Key` atualmente, então o
+`RequestOptions` não expõe esse campo. Quando a API adicionar suporte, ele
+entrará em uma release menor aditiva.
+:::
+
+## Sandbox vs. Produção
+
+:::warning A separação produção vs. teste fica na conta, não no SDK
+A escolha entre **produção** e **teste (homologação)** é definida na
+configuração da sua conta em [app.nfe.io](https://app.nfe.io) (lado servidor) —
+**não** pela chave de API nem pelo SDK.
+:::
+
+O enum `Nfe\Environment` (`Production` / `Sandbox`) é aceito e validado, mas
+hoje **não altera** endpoints, chaves ou comportamento — está reservado para uso
+futuro.
+
+:::note Ambiente SEFAZ é outra coisa
+Os recursos de produto e consumidor (NF-e/NFC-e) aceitam um parâmetro
+**separado** `environment` do tipo `string` (`"Production"` / `"Test"`) nas
+operações de listagem — esse é o ambiente da SEFAZ e é tratado nos guias
+daqueles recursos, não aqui.
+:::
+
+## Transporte PSR-18 (Guzzle, Symfony HttpClient…)
+
+Por padrão o SDK fala HTTP com cURL (`Nfe\Http\CurlTransport`). Para rotear pelo
+cliente HTTP do seu framework, use `Nfe\Http\Psr18Transport` com qualquer
+cliente PSR-18 + fábricas PSR-17 (exige `psr/http-client` e `psr/http-factory`
+instalados no seu projeto):
+
+```php
+use Nfe\Client;
+use Nfe\Config;
+use Nfe\Http\Psr18Transport;
+
+$transport = new Psr18Transport($psr18Client, $requestFactory, $streamFactory);
+$nfe = new Client(config: new Config(apiKey: $key, transport: $transport));
+```
+
+## Próximos passos
+
+- [Emissão assíncrona e polling](./async-and-polling.md) — o contrato HTTP 202.
+- [Tratamento de erros](./errors.md) — `catch` por tipo.
+- [Roteamento multi-host](./multi-host-routing.md) — hosts e chaves por família.

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -1,0 +1,82 @@
+---
+title: Downloads de PDF e XML no SDK PHP da NFE.io
+sidebar_label: Downloads
+sidebar_position: 7
+slug: downloads
+description: Baixe PDF/XML das notas. Todos os métodos de download do SDK PHP devolvem os bytes crus como string — salve com file_put_contents, sem contratos especiais por recurso.
+---
+
+# Downloads
+
+Os recursos de nota expõem métodos para baixar PDF e XML. No SDK PHP o contrato
+é **um só**: todo método `download*()` / `getPdf()` / `getXml()` retorna os
+**bytes crus do arquivo como uma `string` PHP** — não um stream, não um objeto
+de arquivo, não uma URI.
+
+## Salvando um arquivo
+
+```php
+file_put_contents(
+    'nota.pdf',
+    $nfe->serviceInvoices->downloadPdf($companyId, $invoiceId),
+);
+
+file_put_contents(
+    'nota.xml',
+    $nfe->serviceInvoices->downloadXml($companyId, $invoiceId),
+);
+```
+
+O mesmo padrão vale para todos os recursos:
+
+```php
+// NF-e (DANFE) emitida pela sua empresa:
+$pdf = $nfe->productInvoices->downloadPdf($companyId, $invoiceId);
+
+// NF-e de terceiros, por chave de acesso (44 dígitos):
+$danfe = $nfe->productInvoiceQuery->downloadPdf($accessKey);
+
+// XML de CT-e recebido:
+$xml = $nfe->transportationInvoices->downloadXml($companyId, $accessKey);
+
+// Documentos de entrada (DF-e):
+$pdf = $nfe->inboundProductInvoices->getPdf($companyId, $accessKey);
+```
+
+:::tip Diferença em relação aos SDKs Node.js e Ruby
+No SDK Ruby, os downloads de `product_invoices` devolvem um objeto com a URI do
+arquivo; no Node, um `Buffer`. No PHP não há exceção: **todos** os downloads —
+inclusive os de `productInvoices` — devolvem a `string` de bytes pronta para
+gravar. Não portar esse detalhe cegamente de outro SDK.
+:::
+
+## Métodos de download por recurso
+
+| Recurso | Métodos |
+| --- | --- |
+| `serviceInvoices` | `downloadPdf`, `downloadXml` |
+| `productInvoices` | `downloadPdf`, `downloadXml`, `downloadRejectionXml`, `downloadEpecXml`, `downloadCorrectionLetterPdf`, `downloadCorrectionLetterXml` |
+| `consumerInvoices` | `downloadPdf`, `downloadXml`, `downloadRejectionXml` |
+| `transportationInvoices` | `downloadXml`, `downloadEventXml` |
+| `inboundProductInvoices` | `getPdf`, `getXml`, `getEventXml` |
+| `productInvoiceQuery` | `downloadPdf`, `downloadXml` |
+| `consumerInvoiceQuery` | `downloadXml` |
+
+## Como o SDK segue o redirecionamento para o CDN
+
+Alguns endpoints de download respondem com um redirect (302/303/307) para um CDN
+(por exemplo, S3). O SDK segue o redirecionamento **em uma segunda requisição
+sem o header `Authorization`** — sua chave de API nunca chega ao host do CDN.
+Isso é transparente: você recebe os bytes finais.
+
+:::note Memória
+Como o retorno é uma `string` em memória, arquivos muito grandes (ZIPs de
+período inteiro, por exemplo) ocupam RAM proporcional ao tamanho. Para volumes
+altos, baixe em lotes menores.
+:::
+
+## Próximos passos
+
+- [Roteamento multi-host](./multi-host-routing.md) — em qual host cada download vive.
+- [Paginação](./pagination.md) — liste notas antes de baixá-las.
+- [Cookbook por recurso](./recursos/) — exemplos completos por recurso.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,152 @@
+---
+title: Tratamento de erros no SDK PHP da NFE.io
+sidebar_label: Tratamento de erros
+sidebar_position: 4
+slug: tratamento-de-erros
+description: A hierarquia Nfe\Exception, a tabela de códigos HTTP por classe, padrões idiomáticos de catch com instanceof, validação client-side fail-fast e erros de rede.
+---
+
+# Tratamento de erros
+
+Todos os erros de API do SDK derivam de `Nfe\Exception\ApiErrorException` (que
+estende `RuntimeException`), então você pode capturar a família inteira com um
+único `catch`. Esta página descreve a hierarquia, os códigos HTTP mapeados,
+padrões de `catch` por tipo, a validação client-side e os erros de rede.
+
+## A hierarquia de erros
+
+Todas as classes vivem em `Nfe\Exception\`:
+
+| Classe | Código HTTP | Quando ocorre |
+| --- | --- | --- |
+| `ApiErrorException` | — | Base de toda a família. |
+| `AuthenticationException` | 401 | Chave de API ausente ou inválida. |
+| `AuthorizationException` | 403 | Chave válida, mas sem permissão/plano para o recurso. |
+| `InvalidRequestException` | 400 / 422 | Requisição malformada, reprovada na validação — ou validação **local** (síncrona, antes do HTTP). |
+| `NotFoundException` | 404 | Recurso não existe. |
+| `RateLimitException` | 429 | Excesso de requisições. |
+| `ServerException` | 5xx | Falha no servidor da API. |
+| `ApiConnectionException` | — | Falha de rede/cURL (DNS, conexão recusada, TLS, timeout). |
+| `SignatureVerificationException` | — | Assinatura de webhook reprovada. |
+
+:::note Não há type guards — use `instanceof`
+O SDK não expõe funções `isXxx()`. Capture as subclasses específicas primeiro e
+`ApiErrorException` como rede de segurança.
+:::
+
+## Contexto carregado pelos erros HTTP
+
+Erros derivados de uma resposta HTTP carregam contexto público para
+diagnóstico: `->statusCode`, `->responseBody`, `->responseHeaders` e
+`->errorCode`, além do `getMessage()` usual.
+
+```php
+use Nfe\Exception\ApiErrorException;
+
+try {
+    $nfe->serviceInvoices->retrieve($companyId, $invoiceId);
+} catch (ApiErrorException $e) {
+    $e->statusCode;      // ex.: 404
+    $e->errorCode;       // código de erro legível por máquina, quando presente
+    $e->getMessage();    // mensagem de diagnóstico
+}
+```
+
+:::warning Cuidado ao logar `responseBody`/`responseHeaders`
+O corpo e os headers brutos podem conter dados sensíveis (PII do payload,
+detalhes da conta). Prefira logar `statusCode` + `errorCode` + `getMessage()` e
+reserve o corpo bruto para depuração pontual.
+:::
+
+## Padrões de `catch` por tipo
+
+Capture do mais específico para o mais genérico:
+
+```php
+use Nfe\Exception\ApiConnectionException;
+use Nfe\Exception\ApiErrorException;
+use Nfe\Exception\AuthenticationException;
+use Nfe\Exception\AuthorizationException;
+use Nfe\Exception\InvalidRequestException;
+use Nfe\Exception\RateLimitException;
+use Nfe\Exception\ServerException;
+
+try {
+    $result = $nfe->serviceInvoices->create($companyId, $payload);
+} catch (AuthenticationException $e) {
+    // 401 — revise a chave de API.
+    throw $e;
+} catch (AuthorizationException $e) {
+    // 403 — a chave não tem permissão/plano para este recurso.
+    throw $e;
+} catch (InvalidRequestException $e) {
+    // 400/422 ou validação local — corrija o payload.
+    error_log("Requisição inválida: {$e->getMessage()}");
+} catch (RateLimitException $e) {
+    // 429 — aguarde antes de tentar de novo (o SDK já retentou com backoff).
+    throw $e;
+} catch (ServerException $e) {
+    // 5xx — falha do lado do servidor; reportar/retentar com backoff.
+    throw $e;
+} catch (ApiConnectionException $e) {
+    // Falha de rede (DNS, conexão recusada, TLS, timeout).
+    throw $e;
+} catch (ApiErrorException $e) {
+    // Rede de segurança para qualquer erro do SDK.
+    error_log("[{$e->errorCode}] HTTP {$e->statusCode}: {$e->getMessage()}");
+    throw $e;
+}
+```
+
+## Validação client-side (fail-fast)
+
+Validações client-side (id de empresa vazio, chave de acesso com tamanho errado,
+CEP/UF inválidos, texto de carta de correção vazio) lançam
+`InvalidRequestException` **antes** de qualquer requisição HTTP:
+
+```php
+use Nfe\Exception\InvalidRequestException;
+
+try {
+    $nfe->serviceInvoices->retrieve('', 'abc');
+} catch (InvalidRequestException $e) {
+    // Lançada de forma síncrona, sem rede. $e->statusCode é null aqui.
+    error_log($e->getMessage());
+}
+```
+
+:::note Sem `statusCode` na validação local
+Por não vir de uma resposta HTTP, um `InvalidRequestException` client-side tem
+`statusCode` nulo — diferente do mesmo erro vindo de um 400/422.
+:::
+
+## Retentativas automáticas
+
+Antes de qualquer exceção chegar ao seu código, o transporte já retentou
+**HTTP 429** e **5xx** conforme a `Nfe\Http\RetryPolicy` configurada (padrão: 3
+retentativas com backoff exponencial e jitter). Um `RateLimitException` ou
+`ServerException` capturado significa que o orçamento de retentativas se
+esgotou. Erros 4xx de negócio não são retentados. Veja
+[Configuração](./configuration.md).
+
+## Erros de rede
+
+Quando nenhuma troca HTTP se completa, o SDK lança `ApiConnectionException` em
+vez de devolver uma resposta — DNS, conexão recusada, falha de TLS, timeout de
+conexão ou leitura.
+
+```php
+use Nfe\Exception\ApiConnectionException;
+
+try {
+    $nfe->companies->list();
+} catch (ApiConnectionException $e) {
+    error_log("Falha de conexão: {$e->getMessage()}");
+}
+```
+
+## Próximos passos
+
+- [Emissão assíncrona e polling](./async-and-polling.md) — trate falhas no loop.
+- [Configuração](./configuration.md) — `timeout` e `RetryPolicy`.
+- [Webhooks](./webhooks.md) — `SignatureVerificationException` na prática.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,130 @@
+---
+title: Primeiros passos com o SDK PHP da NFE.io
+sidebar_label: Primeiros passos
+sidebar_position: 1
+slug: primeiros-passos
+description: Instale o pacote nfe/nfe via Composer, crie um Nfe\Client, emita sua primeira NFS-e e acompanhe o processamento com polling.
+---
+
+# Primeiros passos
+
+Este guia cobre a instalação, a criação do cliente e a emissão da sua primeira
+nota fiscal de serviço (NFS-e), incluindo o acompanhamento do processamento.
+
+## 1. Instale o pacote
+
+```sh
+composer require "nfe/nfe:^3.0"
+```
+
+:::note Requisitos
+PHP **8.2** ou superior, com as extensões `ext-curl`, `ext-json` e
+`ext-mbstring`. O SDK não tem dependências de runtime — usa o cURL nativo do
+PHP.
+:::
+
+## 2. Crie um cliente
+
+O construtor usa **argumentos nomeados**:
+
+```php
+use Nfe\Client;
+
+$nfe = new Client(apiKey: $_ENV['NFE_API_KEY']);
+```
+
+Recursos de **dados** (CEP, CNPJ, CPF, consultas de NF-e/NFC-e) usam uma segunda
+chave opcional, `dataApiKey:`, com fallback para `apiKey`. Todas as opções estão
+em [Configuração](./configuration.md).
+
+:::note O SDK não lê variáveis de ambiente sozinho
+Diferente de outros SDKs da NFE.io, o cliente PHP **não** faz fallback
+automático para `NFE_API_KEY`/`NFE_DATA_API_KEY` — passe as chaves
+explicitamente (por exemplo via `$_ENV`, como acima).
+:::
+
+## 3. Emita uma NFS-e
+
+Os recursos ficam em propriedades `public readonly` do cliente — acesse-os
+diretamente:
+
+```php
+$result = $nfe->serviceInvoices->create('55df4dc6b6cd9007e4f13ee8', [
+    'cityServiceCode' => '2690',
+    'description'     => 'Manutenção e suporte técnico',
+    'servicesAmount'  => 100.0,
+    'borrower'        => [
+        'federalTaxNumber' => 191,
+        'name'             => 'Banco do Brasil SA',
+    ],
+]);
+```
+
+:::tip Chaves em camelCase
+O corpo (`array $data`) usa as chaves em camelCase, exatamente como a API
+espera.
+:::
+
+## 4. Trate o retorno discriminado
+
+A emissão é assíncrona. `create()` devolve um **union type nativo**
+(`ServiceInvoicePending|ServiceInvoiceIssued`) — distinga com `instanceof`
+contra as interfaces marcadoras `Nfe\Response\Pending` e `Nfe\Response\Issued`:
+
+```php
+use Nfe\Response\Pending;
+
+if ($result instanceof Pending) {
+    $invoiceId = $result->invoiceId();  // id para reconsultar enquanto processa (HTTP 202)
+    $location  = $result->location();   // valor bruto do header Location
+} else {
+    $invoice = $result->resource();     // NFS-e já materializada (HTTP 201)
+}
+```
+
+## 5. Acompanhe até um estado terminal (polling)
+
+Não existe `createAndWait()` na `v3.0` — faça polling com `getStatus()` até um
+estado terminal, usando `Nfe\Util\FlowStatus::isTerminal()`:
+
+```php
+use Nfe\Response\Pending;
+use Nfe\Util\FlowStatus;
+
+if ($result instanceof Pending) {
+    $companyId = '55df4dc6b6cd9007e4f13ee8';
+    $invoiceId = $result->invoiceId();
+
+    do {
+        sleep(3); // algumas prefeituras levam minutos
+        $status = $nfe->serviceInvoices->getStatus($companyId, $invoiceId);
+        $flow   = $status['flowStatus'] ?? '';
+    } while (!FlowStatus::isTerminal($flow));
+
+    if ($flow === 'Issued') {
+        $invoice = $nfe->serviceInvoices->retrieve($companyId, $invoiceId);
+    } else {
+        // 'IssueFailed' | 'Cancelled' | 'CancelFailed'
+    }
+}
+```
+
+:::warning Terminal não significa sucesso
+`FlowStatus::isTerminal()` retorna `true` também para os estados de **falha**
+(`IssueFailed`, `CancelFailed`). Sempre inspecione o status concreto antes de
+considerar a nota emitida. Veja
+[Emissão assíncrona e polling](./async-and-polling.md).
+:::
+
+:::warning Produção vs. teste
+A separação **produção vs. teste (homologação)** é definida na configuração da
+sua conta em [app.nfe.io](https://app.nfe.io) — **não** pela chave de API nem
+pelo SDK. O argumento `environment:` do cliente está reservado para uso futuro.
+:::
+
+## Próximos passos
+
+- [Configuração](./configuration.md) — todas as opções do cliente.
+- [Emissão assíncrona e polling](./async-and-polling.md) — o contrato 202 em detalhe.
+- [Tratamento de erros](./errors.md) — `catch` por tipo.
+- [Webhooks](./webhooks.md) — receba a conclusão por push em vez de polling.

--- a/docs/multi-host-routing.md
+++ b/docs/multi-host-routing.md
@@ -1,0 +1,91 @@
+---
+title: Roteamento multi-host no SDK PHP da NFE.io
+sidebar_label: Roteamento multi-host
+sidebar_position: 8
+slug: roteamento-multi-host
+description: Entenda como o SDK roteia cada recurso para o host correto (api.nfe.io, api.nfse.io e os hosts de dados), o modelo de duas chaves e o override por requisição com RequestOptions.
+---
+
+# Roteamento multi-host
+
+A plataforma NFE.io expõe várias APIs em hosts diferentes. O SDK roteia cada
+recurso **automaticamente** para o host certo — nenhum recurso hard-codeia uma
+URL. Cada recurso declara uma **família** de API e obtém seu host e sua chave a
+partir do `Nfe\Config`.
+
+## Famílias, hosts e recursos
+
+| Família | Host | Recursos |
+| --- | --- | --- |
+| `main` | `api.nfe.io` (`/v1`) | `serviceInvoices`, `companies`, `legalPeople`, `naturalPeople`, `webhooks` |
+| `cte` | `api.nfse.io` (`/v2`) | `productInvoices`, `consumerInvoices`, `transportationInvoices`, `inboundProductInvoices`, `taxCalculation`, `taxCodes`, `stateTaxes` |
+| `addresses` | `address.api.nfe.io/v2` | consulta de endereços (CEP) |
+| `legal-entity` | `legalentity.api.nfe.io` | consulta de pessoa jurídica (CNPJ) |
+| `natural-person` | `naturalperson.api.nfe.io` | consulta de pessoa física (CPF) |
+| `nfe-query` | `nfe.api.nfe.io` | `productInvoiceQuery`, `consumerInvoiceQuery` |
+
+:::note O segmento de versão
+Para a família `main`, o `/v1` é fornecido pela versão de API de cada recurso,
+não pelo host. O host de `addresses` já embute o `/v2`. Uma família desconhecida
+cai no host `main` como padrão seguro.
+:::
+
+## Modelo de duas chaves
+
+O SDK usa duas chaves de API. As **famílias de dados** preferem `dataApiKey`
+(com fallback para `apiKey`); todas as outras famílias usam `apiKey`.
+
+As famílias de dados são:
+
+- `addresses` (CEP)
+- `legal-entity` (CNPJ)
+- `natural-person` (CPF)
+- `nfe-query` (consultas de NF-e/NFC-e por chave de acesso)
+
+```php
+$nfe = new Nfe\Client(
+    apiKey: $_ENV['NFE_API_KEY'],
+    dataApiKey: $_ENV['NFE_DATA_API_KEY'] ?? null,
+);
+```
+
+:::warning `cte` NÃO é família de dados
+A família `cte` (`api.nfse.io` — emissão de NF-e/NFC-e, CT-e, entrada, cálculo
+de impostos, tax codes e inscrições estaduais) usa a **`apiKey` principal**, e
+não a `dataApiKey`. Neste SDK a emissão é uma capacidade central, não uma
+consulta de dados. Código Node portado que dependia de `dataApiKey` para
+`api.nfse.io` passa a enviar silenciosamente a chave principal.
+:::
+
+:::tip 403 nas famílias de dados
+Um `AuthorizationException` (403) em `addresses`/`legalEntityLookup`/
+`naturalPersonLookup`/`productInvoiceQuery` com uma chave principal válida
+normalmente significa que o plano dessa chave não inclui o produto de dados.
+Informe uma `dataApiKey` provisionada para o plano de dados.
+:::
+
+## Override por requisição: `RequestOptions->baseUrl`
+
+Para apontar **uma chamada** para outro host (mock, proxy, ambiente de testes
+próprio), use o `Nfe\Http\RequestOptions` que todo método aceita como último
+argumento:
+
+```php
+use Nfe\Http\RequestOptions;
+
+$invoice = $nfe->serviceInvoices->retrieve(
+    $companyId,
+    $invoiceId,
+    new RequestOptions(baseUrl: 'https://mock.local/nfe'),
+);
+```
+
+Para redirecionar **todo** o tráfego (testes de integração, gravação de
+cassetes), injete um `Nfe\Http\Transport` customizado no `Nfe\Config` — o SDK
+não tem um mapa global de overrides por família.
+
+## Próximos passos
+
+- [Configuração](./configuration.md) — duas chaves, `RequestOptions` e transportes.
+- [Downloads](./downloads.md) — o hop para o CDN sem `Authorization`.
+- [Paginação](./pagination.md) — formas de paginação por família.

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -1,0 +1,119 @@
+---
+title: Paginação de listas no SDK PHP da NFE.io
+sidebar_label: Paginação
+sidebar_position: 6
+slug: paginacao
+description: Itere listas com Nfe\Util\ListResponse e leia os metadados de página em Nfe\Util\ListPage — paginação por página (pageIndex 1-based) ou por cursor, conforme o recurso.
+---
+
+# Paginação
+
+Os métodos `list()` retornam um `Nfe\Util\ListResponse` com os itens hidratados
+em `->data` e os metadados de paginação em `->page`. **Não há iterador
+auto-paginante** — para avançar, chame `list()` de novo com a próxima página ou
+o próximo cursor.
+
+## `Nfe\Util\ListResponse`
+
+Tem dois membros públicos:
+
+- `->data` — o array de DTOs hidratados (`list<T>`).
+- `->page` — um `Nfe\Util\ListPage` com os metadados de paginação.
+
+```php
+$page = $nfe->serviceInvoices->list($companyId, ['pageIndex' => 1, 'pageCount' => 50]);
+
+foreach ($page->data as $invoice) {
+    echo $invoice->id, PHP_EOL;
+}
+
+$ids = array_map(fn($i) => $i->id, $page->data);
+```
+
+## `Nfe\Util\ListPage`
+
+Os endpoints da NFE.io paginam em **uma de duas formas**, e cada recurso
+preenche apenas a metade relevante (a outra fica `null`):
+
+- **Por página** — `->pageIndex` / `->pageCount`.
+- **Por cursor** — `->startingAfter` / `->endingBefore`.
+
+`->total` é opcional e pode aparecer em qualquer uma das formas.
+
+:::warning `pageIndex` é 1-based
+O primeiro índice de página é **1**, não 0 — em `serviceInvoices`,
+`consumerInvoices`, `companies` e `taxCodes`. Pedir `pageIndex => 0` não retorna
+a primeira página.
+:::
+
+## Qual recurso usa qual forma
+
+| Recurso | Forma de paginação |
+| --- | --- |
+| `serviceInvoices->list()` | por página (`pageIndex` 1-based / `pageCount`) |
+| `consumerInvoices->list()` | por página |
+| `companies->list()` | por página (+ `listAll()` client-side) |
+| `taxCodes->list*()` | por página (`pageCount` máx. 50; resposta própria) |
+| `productInvoices->list()` | por cursor (`startingAfter` / `limit`) — `environment` obrigatório |
+| `stateTaxes->list()` | por cursor |
+
+### Por página: `serviceInvoices`
+
+```php
+$page = $nfe->serviceInvoices->list($companyId, [
+    'pageIndex' => 1,
+    'pageCount' => 50,
+]);
+
+// Próxima página:
+$page2 = $nfe->serviceInvoices->list($companyId, [
+    'pageIndex' => 2,
+    'pageCount' => 50,
+]);
+```
+
+`serviceInvoices` também aceita filtros de data como `issuedBegin` e
+`issuedEnd` nas mesmas opções.
+
+### Por cursor: `productInvoices`
+
+:::warning `environment` é obrigatório
+Em `productInvoices->list()`, o argumento `$options` é **obrigatório** (não tem
+default) e precisa conter `environment` — uma string `"Production"` ou
+`"Test"` (o ambiente da SEFAZ).
+:::
+
+```php
+$page = $nfe->productInvoices->list($companyId, [
+    'environment' => 'Production',
+    'limit'       => 50,
+]);
+
+// Avance usando o cursor da página anterior:
+$next = $nfe->productInvoices->list($companyId, [
+    'environment'   => 'Production',
+    'startingAfter' => $page->page->startingAfter,
+    'limit'         => 50,
+]);
+```
+
+### Auto-paginação client-side: `companies->listAll()`
+
+`companies` oferece um helper que percorre todas as páginas por você e devolve
+um array simples:
+
+```php
+$todas = $nfe->companies->listAll(); // array<Company>
+```
+
+:::note `taxCodes` retorna um tipo próprio
+Os métodos de `taxCodes` retornam `TaxCodePaginatedResponse` (com
+`currentPage`, `totalPages`, `totalCount` e `items`) em vez de `ListResponse` —
+veja o [cookbook de códigos fiscais](./recursos/tax-codes.md).
+:::
+
+## Próximos passos
+
+- [Downloads](./downloads.md) — baixe os arquivos das notas listadas.
+- [Webhooks](./webhooks.md) — receba eventos por push em vez de listar.
+- [Roteamento multi-host](./multi-host-routing.md) — em qual host cada recurso vive.

--- a/docs/recursos/_category_.json
+++ b/docs/recursos/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Recursos (cookbook)",
+  "position": 10,
+  "collapsed": true,
+  "link": { "type": "generated-index", "slug": "recursos", "title": "Recursos (cookbook)" }
+}

--- a/docs/recursos/addresses.md
+++ b/docs/recursos/addresses.md
@@ -1,0 +1,66 @@
+---
+title: Consulta de endereços (addresses) no SDK PHP da NFE.io
+sidebar_label: Endereços
+sidebar_position: 10
+slug: enderecos
+description: Consulta de endereços por CEP com $nfe->addresses->lookupByPostalCode no host address.api.nfe.io/v2 — família de dados, usa a dataApiKey.
+---
+
+# Consulta de endereços (`addresses`)
+
+O recurso `$nfe->addresses` consulta endereços **por CEP**. Faz parte da família
+de **dados** `addresses`, servida por `address.api.nfe.io/v2` (o host já embute
+a versão).
+
+:::note Família de dados — configure `dataApiKey`
+`addresses` usa a `dataApiKey` quando presente, com **fallback** para a
+`apiKey`. Configure `dataApiKey:` para separar a chave de consulta da chave de
+emissão. Veja [Configuração](../configuration.md).
+:::
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `lookupByPostalCode($cep)` | Consulta um endereço por CEP. | `AddressLookupResponse` |
+
+:::warning CEP é o único endpoint
+Não existe busca por termo livre nem por filtro — `lookupByPostalCode()` é o
+único método. Não procure `search()`/`lookupByTerm()`: esses endpoints não
+existem mais na API.
+:::
+
+## Consultar por CEP
+
+```php
+$nfe = new Nfe\Client(
+    apiKey: $_ENV['NFE_API_KEY'],
+    dataApiKey: $_ENV['NFE_DATA_API_KEY'] ?? null,
+);
+
+$resposta = $nfe->addresses->lookupByPostalCode('01310-100');
+
+$endereco = $resposta->addresses[0];
+$endereco['street'];         // "Avenida Paulista"
+$endereco['city'] ?? null;   // dados do município
+
+$resposta->raw;              // payload original completo, se precisar
+```
+
+O CEP é aceito com ou sem hífen e é normalizado para 8 dígitos.
+
+:::warning CEP é validado antes do HTTP
+Um CEP que não normalize para **8 dígitos** lança
+`Nfe\Exception\InvalidRequestException` **antes** de qualquer requisição. Veja
+[Tratamento de erros](../errors.md).
+:::
+
+:::note O envelope `{ address }` é desembrulhado
+A API responde `{ "address": { … } }`; o SDK desembrulha para
+`->addresses` — uma lista de **1 elemento** — para manter o shape estável.
+:::
+
+## Veja também
+
+- [Configuração](../configuration.md) — modelo de duas chaves e `dataApiKey`.
+- [Consulta de CNPJ](./legal-entity-lookup.md) e [Consulta de CPF](./natural-person-lookup.md) — outras famílias de dados.

--- a/docs/recursos/companies.md
+++ b/docs/recursos/companies.md
@@ -1,0 +1,105 @@
+---
+title: Empresas (companies) no SDK PHP da NFE.io
+sidebar_label: Empresas
+sidebar_position: 6
+slug: empresas
+description: CRUD de empresas emissoras e leitura do status do certificado digital no recurso companies do SDK PHP da NFE.io — escopo de conta, remove() e listAll().
+---
+
+# Empresas (`companies`)
+
+O recurso `$nfe->companies` gerencia as empresas emissoras da sua conta — CRUD
+completo mais a **leitura** do status do certificado digital. Tem escopo de
+**conta** (não recebe `$companyId` como primeiro argumento), faz parte da
+família `main` servida por `api.nfe.io` (`/v1`) e usa a `apiKey`.
+
+:::note Exclusão é `remove()`, não `delete()`
+Para excluir uma empresa, chame `companies->remove($companyId)` — retorna um
+`array{deleted, id}`. O nome mantém paridade com os SDKs Node e Ruby.
+:::
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `create($data)` | Cria uma empresa emissora. | `Company` |
+| `list($options = [])` | Lista paginada (`pageIndex` **1-based**). | `ListResponse` |
+| `listAll()` | Todas as empresas (auto-paginação client-side). | `array<Company>` |
+| `retrieve($companyId)` | Consulta por id. | `Company` |
+| `update($companyId, $data)` | Atualiza. | `Company` |
+| `remove($companyId)` | Exclui. | `array{deleted, id}` |
+| `findByTaxNumber($taxNumber)` | Busca por CNPJ/CPF (varredura client-side). | `?Company` |
+| `findByName($name)` | Busca por nome (varredura client-side). | `array<Company>` |
+| `getCertificateStatus($companyId, $expiringSoonThreshold = 30)` | Status do certificado digital. | `CertificateStatus` |
+| `checkCertificateExpiration($companyId, $thresholdDays = 30)` | Alerta de expiração. | `array` |
+| `getCompaniesWithCertificates()` | Empresas com certificado instalado. | `array<Company>` |
+| `getCompaniesWithExpiringCertificates($thresholdDays = 30)` | Empresas com certificado a vencer. | `array<Company>` |
+
+:::warning Upload de certificado não está no SDK
+O transporte do SDK é JSON-only (sem multipart) — **não** há
+`uploadCertificate()`/`validateCertificate()` na `v3.0`. Faça o upload do
+certificado `.pfx` pelo painel [app.nfe.io](https://app.nfe.io) (ou pela API
+REST diretamente); use o SDK para **ler** o status e monitorar a expiração.
+:::
+
+## Exemplos
+
+### Criar e recuperar uma empresa
+
+```php
+$company = $nfe->companies->create([
+    'name'             => 'Acme Serviços LTDA',
+    'federalTaxNumber' => 12345678000199,
+    'email'            => 'fiscal@acme.com.br',
+]);
+
+$nfe->companies->retrieve($company->id);
+```
+
+:::note `federalTaxNumber` é `int` para empresas
+No DTO `Company` (e `LegalPerson`), `federalTaxNumber` é inteiro; em
+`NaturalPerson` é string. O SDK não valida nem coage no create — envie o tipo
+que a API espera.
+:::
+
+### Paginar e localizar empresas
+
+```php
+// Uma página por vez (pageIndex é 1-based):
+$page = $nfe->companies->list(['pageIndex' => 1, 'pageCount' => 50]);
+foreach ($page->data as $c) {
+    echo $c->name, PHP_EOL;
+}
+
+// Todas as empresas (auto-paginação client-side):
+$todas = $nfe->companies->listAll();
+
+// Buscas auxiliares (filtragem no cliente):
+$acme = $nfe->companies->findByTaxNumber('12.345.678/0001-99');
+$semelhantes = $nfe->companies->findByName('acme');
+```
+
+:::warning Helpers de busca não são otimizados
+`findByTaxNumber`, `findByName`, `listAll`, `getCompaniesWithCertificates` e
+`getCompaniesWithExpiringCertificates` percorrem **todas** as páginas e filtram
+no cliente. Evite em contas com muitas empresas.
+:::
+
+### Monitorar o certificado digital
+
+```php
+$status = $nfe->companies->getCertificateStatus($company->id);
+$status->daysUntilExpiration;   // calculado client-side a partir de expiresOn
+$status->isExpiringSoon;        // threshold padrão: 30 dias
+
+$alerta = $nfe->companies->checkCertificateExpiration($company->id, thresholdDays: 15);
+
+// Varredura da conta inteira:
+$vencendo = $nfe->companies->getCompaniesWithExpiringCertificates(thresholdDays: 30);
+```
+
+## Veja também
+
+- [Pessoas jurídicas](./legal-people.md) e [Pessoas físicas](./natural-people.md) — tomadores vinculados à empresa.
+- [Webhooks](./webhooks.md) — eventos por empresa.
+- [Tratamento de erros](../errors.md).

--- a/docs/recursos/consumer-invoice-query.md
+++ b/docs/recursos/consumer-invoice-query.md
@@ -1,0 +1,56 @@
+---
+title: Consulta de cupons fiscais (consumerInvoiceQuery)
+sidebar_label: Consulta de NFC-e/CFe
+sidebar_position: 17
+slug: consulta-nfce
+description: Consulte cupons fiscais CFe-SAT e NFC-e pela chave de acesso de 44 dígitos e baixe o XML com $nfe->consumerInvoiceQuery no host nfe.api.nfe.io.
+---
+
+# Consulta de cupons fiscais (`consumerInvoiceQuery`)
+
+`$nfe->consumerInvoiceQuery` consulta **cupons fiscais** — CFe-SAT e NFC-e —
+pela **chave de acesso de 44 dígitos**. Recurso **global**, servido por
+`nfe.api.nfe.io`.
+
+:::note Família de dados — usa `dataApiKey`
+Como [`productInvoiceQuery`](./product-invoice-query.md), pertence à família
+`nfe-query`: usa a `dataApiKey` com fallback para `apiKey`. Veja
+[Configuração](../configuration.md).
+:::
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `retrieve($accessKey)` | Consulta o cupom pela chave de acesso. | `TaxCoupon` |
+| `downloadXml($accessKey)` | XML do cupom. | `string` (bytes crus) |
+
+## Consultar um cupom
+
+```php
+$accessKey = '35260159596908000152590008719000024150288589'; // 44 dígitos
+
+$cupom = $nfe->consumerInvoiceQuery->retrieve($accessKey);
+```
+
+:::warning Chave de acesso é validada localmente
+A chave precisa ter **44 dígitos numéricos**; um valor fora do formato lança
+`Nfe\Exception\InvalidRequestException` antes de qualquer requisição.
+:::
+
+## Baixar o XML
+
+```php
+file_put_contents('cupom.xml', $nfe->consumerInvoiceQuery->downloadXml($accessKey));
+```
+
+:::note Sem PDF
+Diferente da consulta de NF-e, a consulta de cupons expõe apenas o XML — não há
+`downloadPdf()`.
+:::
+
+## Veja também
+
+- [Consulta de NF-e](./product-invoice-query.md) — o equivalente para NF-e modelo 55.
+- [Notas de consumidor (NFC-e)](./consumer-invoices.md) — emissão de NFC-e.
+- [Configuração](../configuration.md) — modelo de duas chaves.

--- a/docs/recursos/consumer-invoices.md
+++ b/docs/recursos/consumer-invoices.md
@@ -1,0 +1,105 @@
+---
+title: Notas fiscais de consumidor (NFC-e)
+sidebar_label: Notas de consumidor
+sidebar_position: 3
+slug: notas-fiscais-de-consumidor
+description: Emita NFC-e modelo 65 com $nfe->consumerInvoices no host api.nfse.io /v2 — retorno discriminado 202, listagem paginada, cancelamento e inutilização de faixa.
+---
+
+# Notas fiscais de consumidor (NFC-e)
+
+`$nfe->consumerInvoices` cobre a NFC-e (modelo 65) no host `api.nfse.io`, sob
+`/v2`: emissão, listagem, consulta, cancelamento, inutilização de faixa e
+downloads.
+
+A emissão segue o **contrato 202 discriminado** (assíncrona; conclusão via
+webhook): `create()` / `createWithStateTax()` devolvem
+`ConsumerInvoicePending|ConsumerInvoiceIssued`.
+
+:::tip Prefira webhooks
+Como na NF-e, não há `getStatus()` — a conclusão da emissão é orientada a
+webhook. Se precisar de polling, use `retrieve()` e leia o campo de fluxo do
+DTO.
+:::
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `create($companyId, $data)` | Emite a NFC-e. | `ConsumerInvoicePending\|ConsumerInvoiceIssued` |
+| `createWithStateTax($companyId, $stateTaxId, $data)` | Emite vinculada a uma inscrição estadual. | `ConsumerInvoicePending\|ConsumerInvoiceIssued` |
+| `list($companyId, $options = [])` | Lista paginada. | `ListResponse` |
+| `retrieve($companyId, $invoiceId)` | Consulta por id. | `ConsumerInvoice` |
+| `cancel($companyId, $invoiceId)` | Cancela e devolve o modelo atualizado. | `ConsumerInvoice` |
+| `listItems($companyId, $invoiceId)` | Lista os itens da nota. | `array` (arrays crus) |
+| `listEvents($companyId, $invoiceId)` | Lista os eventos fiscais. | `array` (arrays crus) |
+| `downloadPdf($companyId, $invoiceId)` | DANFE NFC-e (PDF). | `string` (bytes crus) |
+| `downloadXml($companyId, $invoiceId)` | XML autorizado. | `string` |
+| `downloadRejectionXml($companyId, $invoiceId)` | XML de rejeição. | `string` |
+| `disableRange($companyId, $data)` | Inutiliza uma faixa de numeração. | `array` |
+
+:::note Diferenças em relação à NF-e
+NFC-e **não** tem carta de correção (CC-e), contingência EPEC nem inutilização
+por nota individual — apenas `disableRange()`. A inutilização aqui usa
+`POST .../disablement` (caminho e verbo diferentes do `disable` da NF-e).
+:::
+
+## Emitir uma NFC-e
+
+```php
+use Nfe\Response\Pending;
+
+$result = $nfe->consumerInvoices->create('55df4dc6b6cd9007e4f13ee8', [
+    'items' => [
+        ['code' => '001', 'description' => 'Produto X', 'quantity' => 2, 'unitAmount' => 25.0],
+    ],
+    'payment' => [
+        ['method' => 'Money', 'amount' => 50.0],
+    ],
+]);
+
+if ($result instanceof Pending) {
+    $result->invoiceId();   // acompanhe via webhook ou retrieve()
+} else {
+    $result->resource();    // Nfe\ConsumerInvoice
+}
+```
+
+## Listar, consultar e cancelar
+
+```php
+$pagina = $nfe->consumerInvoices->list($companyId, [
+    'pageIndex' => 1,      // 1-based
+    'pageCount' => 50,
+]);
+
+$nota = $nfe->consumerInvoices->retrieve($companyId, $invoiceId);
+
+$cancelada = $nfe->consumerInvoices->cancel($companyId, $invoiceId);
+```
+
+## Baixar arquivos
+
+```php
+file_put_contents('nfce.pdf', $nfe->consumerInvoices->downloadPdf($companyId, $invoiceId));
+file_put_contents('nfce.xml', $nfe->consumerInvoices->downloadXml($companyId, $invoiceId));
+```
+
+## Inutilizar uma faixa de numeração
+
+```php
+$nfe->consumerInvoices->disableRange($companyId, [
+    'environment' => 'Production',
+    'serie'       => 1,
+    'state'       => 'SP',
+    'beginNumber' => 200,
+    'lastNumber'  => 210,
+    'reason'      => 'Falha de impressão',
+]);
+```
+
+## Próximos passos
+
+- [Consulta de cupons (CFe-SAT/NFC-e)](./consumer-invoice-query.md) — consulta por chave de acesso.
+- [Notas de produto (NF-e)](./product-invoices.md) — modelo 55.
+- [Webhooks](../webhooks.md) — conclusão por push.

--- a/docs/recursos/inbound-product-invoices.md
+++ b/docs/recursos/inbound-product-invoices.md
@@ -1,0 +1,86 @@
+---
+title: Notas de entrada (NF-e recebidas / DF-e)
+sidebar_label: Notas de entrada
+sidebar_position: 5
+slug: notas-de-entrada
+description: Ative a busca automática de NF-e emitidas contra o seu CNPJ (distribuição DF-e), consulte documentos e eventos, baixe XML/PDF e manifeste-se com $nfe->inboundProductInvoices.
+---
+
+# Notas de entrada (NF-e recebidas)
+
+`$nfe->inboundProductInvoices` cobre a **distribuição DF-e**: NF-e emitidas por
+terceiros contra o seu CNPJ. Vive no host `api.nfse.io`, sob `/v2`, e permite
+ativar a busca automática, consultar documentos e eventos por chave de acesso,
+baixar XML/PDF/JSON e registrar a **manifestação do destinatário**.
+
+:::note Usa a `apiKey` principal
+Apesar de ser um recurso de consulta, a distribuição DF-e **não** é família de
+dados — sempre usa a chave principal.
+:::
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `enableAutoFetch($companyId, $data)` | Ativa a busca automática de documentos. | `InboundSettings` |
+| `disableAutoFetch($companyId)` | Desativa a busca automática. | `InboundSettings` |
+| `getSettings($companyId)` | Configurações atuais. | `InboundSettings` |
+| `getDetails($companyId, $accessKey)` | Detalhes do documento distribuído. | `array` |
+| `getProductInvoiceDetails($companyId, $accessKey)` | Detalhes da NF-e completa. | `array` |
+| `getEventDetails($companyId, $accessKey, $eventKey)` | Detalhes de um evento distribuído. | `array` |
+| `getProductInvoiceEventDetails($companyId, $accessKey, $eventKey)` | Detalhes de um evento da NF-e. | `array` |
+| `getXml($companyId, $accessKey)` | XML do documento. | `string` (bytes crus) |
+| `getEventXml($companyId, $accessKey, $eventKey)` | XML de um evento. | `string` |
+| `getPdf($companyId, $accessKey)` | DANFE em PDF. | `string` |
+| `getJson($companyId, $accessKey)` | Representação JSON do documento. | `array` |
+| `manifest($companyId, $accessKey, $manifestType, $data = [])` | Manifestação do destinatário. | `array` |
+| `reprocessWebhook($companyId, $accessKey)` | Reenvia o webhook do documento. | `array` |
+
+## Ativar a busca automática
+
+```php
+$settings = $nfe->inboundProductInvoices->enableAutoFetch('55df4dc6b6cd9007e4f13ee8', [
+    'startFromDate' => '2026-01-01',
+]);
+```
+
+Depois de ativada, os documentos chegam por [webhook](../webhooks.md) conforme a
+SEFAZ os distribui.
+
+## Consultar um documento recebido
+
+```php
+$accessKey = '35260111222333000181550010000012341000012349';
+
+$detalhes = $nfe->inboundProductInvoices->getDetails($companyId, $accessKey);
+$nfeCompleta = $nfe->inboundProductInvoices->getProductInvoiceDetails($companyId, $accessKey);
+
+file_put_contents('entrada.xml', $nfe->inboundProductInvoices->getXml($companyId, $accessKey));
+file_put_contents('entrada.pdf', $nfe->inboundProductInvoices->getPdf($companyId, $accessKey));
+```
+
+## Manifestação do destinatário
+
+```php
+// Ex.: confirmar a operação
+$nfe->inboundProductInvoices->manifest($companyId, $accessKey, 'Confirmation');
+
+// Ex.: desconhecer a operação, com justificativa no corpo
+$nfe->inboundProductInvoices->manifest($companyId, $accessKey, 'Ignorance', [
+    'reason' => 'Operação não reconhecida',
+]);
+```
+
+## Reprocessar o webhook
+
+Se a sua aplicação perdeu uma entrega, peça o reenvio do evento do documento:
+
+```php
+$nfe->inboundProductInvoices->reprocessWebhook($companyId, $accessKey);
+```
+
+## Próximos passos
+
+- [CT-e (entrada)](./transportation-invoices.md) — o equivalente para conhecimentos de transporte.
+- [Webhooks](../webhooks.md) — verificação de assinatura das entregas.
+- [Consulta de NF-e](./product-invoice-query.md) — consulta pontual por chave de acesso.

--- a/docs/recursos/legal-entity-lookup.md
+++ b/docs/recursos/legal-entity-lookup.md
@@ -1,0 +1,70 @@
+---
+title: Consulta de CNPJ (legalEntityLookup) no SDK PHP da NFE.io
+sidebar_label: Consulta de CNPJ
+sidebar_position: 11
+slug: consulta-cnpj
+description: Consulte dados cadastrais de pessoa jurídica por CNPJ e a inscrição estadual por UF com $nfe->legalEntityLookup no host legalentity.api.nfe.io.
+---
+
+# Consulta de CNPJ (`legalEntityLookup`)
+
+`$nfe->legalEntityLookup` consulta dados cadastrais de **pessoa jurídica** por
+CNPJ, incluindo a inscrição estadual (IE) por UF. Recurso **global** (não recebe
+`$companyId`), servido por `legalentity.api.nfe.io`.
+
+:::note Família de dados — usa `dataApiKey`
+Com fallback para `apiKey`. Um 403 com chave principal válida normalmente
+significa que o plano não inclui o produto de dados. Veja
+[Configuração](../configuration.md).
+:::
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `getBasicInfo($cnpj, $opts = null)` | Dados cadastrais básicos da Receita. | `LegalEntityResponse` |
+| `getStateTaxInfo($state, $cnpj)` | Inscrição estadual na UF. | `LegalEntityResponse` |
+| `getStateTaxForInvoice($state, $cnpj)` | IE apta para emissão de NF-e. | `LegalEntityResponse` |
+| `getSuggestedStateTaxForInvoice($state, $cnpj)` | IE sugerida para a NF-e. | `LegalEntityResponse` |
+
+## Consultar os dados básicos
+
+```php
+$resposta = $nfe->legalEntityLookup->getBasicInfo('11.444.555/0001-49');
+
+$pj = $resposta->legalEntity;      // array com os dados desembrulhados (ou null)
+$pj['name'] ?? null;
+$pj['address'] ?? null;
+
+$resposta->raw;                    // payload completo original
+```
+
+`getBasicInfo()` aceita um segundo argumento com parâmetros de query — por
+exemplo, `['updateAddress' => false, 'updateCityCode' => true]`.
+
+## Consultar a inscrição estadual por UF
+
+```php
+$ie = $nfe->legalEntityLookup->getStateTaxInfo('SP', '11444555000149');
+
+// Variantes voltadas à emissão de NF-e:
+$nfe->legalEntityLookup->getStateTaxForInvoice('SP', '11444555000149');
+$nfe->legalEntityLookup->getSuggestedStateTaxForInvoice('SP', '11444555000149');
+```
+
+:::warning UF é validada localmente
+`$state` é normalizada para maiúsculas; uma UF desconhecida lança
+`Nfe\Exception\InvalidRequestException` antes de qualquer requisição.
+:::
+
+:::tip Enriquecendo cadastros
+Um fluxo comum: consultar o CNPJ aqui e usar o resultado para pré-preencher o
+cadastro do tomador em [`legalPeople`](./legal-people.md) antes de emitir a
+nota.
+:::
+
+## Veja também
+
+- [Consulta de CPF](./natural-person-lookup.md) — o equivalente PF.
+- [Inscrições estaduais](./state-taxes.md) — IEs da **sua** empresa emissora.
+- [Configuração](../configuration.md) — modelo de duas chaves.

--- a/docs/recursos/legal-people.md
+++ b/docs/recursos/legal-people.md
@@ -1,0 +1,86 @@
+---
+title: Pessoas jurídicas (legalPeople) no SDK PHP da NFE.io
+sidebar_label: Pessoas jurídicas
+sidebar_position: 7
+slug: pessoas-juridicas
+description: CRUD de pessoas jurídicas (tomadores PJ) vinculadas a uma empresa com $nfe->legalPeople — create, createBatch sequencial, findByTaxNumber e delete.
+---
+
+# Pessoas jurídicas (`legalPeople`)
+
+`$nfe->legalPeople` gerencia o cadastro de **pessoas jurídicas** (tomadores PJ)
+vinculadas a uma empresa emissora. Escopo de **empresa** (todo método recebe
+`$companyId` como primeiro argumento), família `main` (`api.nfe.io` `/v1`),
+chave principal.
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `list($companyId)` | Lista as pessoas jurídicas da empresa. | `ListResponse` |
+| `create($companyId, $data)` | Cadastra uma PJ. | `LegalPerson` |
+| `retrieve($companyId, $personId)` | Consulta por id. | `LegalPerson` |
+| `update($companyId, $personId, $data)` | Atualiza. | `LegalPerson` |
+| `delete($companyId, $personId)` | Exclui. | `void` |
+| `createBatch($companyId, $batch)` | Cadastra várias em sequência. | `array` |
+| `findByTaxNumber($companyId, $taxNumber)` | Busca por CNPJ (client-side). | `?LegalPerson` |
+
+:::note Exclusão aqui é `delete(): void`
+Diferente de `companies->remove()` (que retorna `{deleted, id}`), pessoas usam
+`delete()` e não retornam corpo.
+:::
+
+## Exemplos
+
+### Cadastrar uma pessoa jurídica
+
+```php
+$pessoa = $nfe->legalPeople->create('55df4dc6b6cd9007e4f13ee8', [
+    'federalTaxNumber' => 11444555000149,   // int para PJ
+    'name'             => 'Cliente Exemplo LTDA',
+    'email'            => 'contato@exemplo.com.br',
+    'address'          => [
+        'postalCode' => '01310-100',
+        'street'     => 'Avenida Paulista',
+        'number'     => '1000',
+        'city'       => ['code' => '3550308', 'name' => 'São Paulo'],
+        'state'      => 'SP',
+    ],
+]);
+```
+
+:::warning `federalTaxNumber` é `int` para PJ
+No DTO `LegalPerson`, `federalTaxNumber` é `?int` (em `NaturalPerson` é
+`?string`). O SDK não valida nem coage no create — envie o tipo correto.
+:::
+
+### Lote sequencial
+
+```php
+$resultado = $nfe->legalPeople->createBatch($companyId, [
+    ['federalTaxNumber' => 11444555000149, 'name' => 'Empresa A'],
+    ['federalTaxNumber' => 61365284000104, 'name' => 'Empresa B'],
+]);
+```
+
+:::note `createBatch` é sequencial
+As criações são feitas **uma a uma** (sem paralelismo) — para listas grandes,
+espere tempo proporcional ao tamanho do lote.
+:::
+
+### Buscar, atualizar e excluir
+
+```php
+$pj = $nfe->legalPeople->findByTaxNumber($companyId, 11444555000149);
+
+if ($pj !== null) {
+    $nfe->legalPeople->update($companyId, $pj->id, ['email' => 'novo@exemplo.com.br']);
+    $nfe->legalPeople->delete($companyId, $pj->id);   // void
+}
+```
+
+## Veja também
+
+- [Pessoas físicas](./natural-people.md) — o equivalente PF.
+- [Consulta de CNPJ](./legal-entity-lookup.md) — enriqueça o cadastro com dados da Receita.
+- [Notas de serviço](./service-invoices.md) — use a PJ como `borrower`.

--- a/docs/recursos/natural-people.md
+++ b/docs/recursos/natural-people.md
@@ -1,0 +1,65 @@
+---
+title: Pessoas físicas (naturalPeople) no SDK PHP da NFE.io
+sidebar_label: Pessoas físicas
+sidebar_position: 8
+slug: pessoas-fisicas
+description: CRUD de pessoas físicas (tomadores PF) vinculadas a uma empresa com $nfe->naturalPeople — federalTaxNumber como string, createBatch sequencial e findByTaxNumber.
+---
+
+# Pessoas físicas (`naturalPeople`)
+
+`$nfe->naturalPeople` gerencia o cadastro de **pessoas físicas** (tomadores PF)
+vinculadas a uma empresa emissora. Escopo de **empresa**, família `main`
+(`api.nfe.io` `/v1`), chave principal. A API é idêntica à de
+[pessoas jurídicas](./legal-people.md), com uma diferença de tipo importante.
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `list($companyId)` | Lista as pessoas físicas da empresa. | `ListResponse` |
+| `create($companyId, $data)` | Cadastra uma PF. | `NaturalPerson` |
+| `retrieve($companyId, $personId)` | Consulta por id. | `NaturalPerson` |
+| `update($companyId, $personId, $data)` | Atualiza. | `NaturalPerson` |
+| `delete($companyId, $personId)` | Exclui. | `void` |
+| `createBatch($companyId, $batch)` | Cadastra várias em sequência. | `array` |
+| `findByTaxNumber($companyId, $taxNumber)` | Busca por CPF (client-side). | `?NaturalPerson` |
+
+## Exemplos
+
+### Cadastrar uma pessoa física
+
+```php
+$pessoa = $nfe->naturalPeople->create('55df4dc6b6cd9007e4f13ee8', [
+    'federalTaxNumber' => '31119298000',   // string para PF
+    'name'             => 'Maria da Silva',
+    'email'            => 'maria@example.com',
+]);
+```
+
+:::warning `federalTaxNumber` é `string` para PF
+No DTO `NaturalPerson`, `federalTaxNumber` é `?string` — diferente de
+`LegalPerson`/`Company`, onde é `?int`. O SDK não valida nem coage no create;
+enviar o tipo errado pode causar rejeição ou perda de zeros à esquerda do CPF.
+:::
+
+### Lote, busca e exclusão
+
+```php
+$nfe->naturalPeople->createBatch($companyId, [
+    ['federalTaxNumber' => '31119298000', 'name' => 'Maria da Silva'],
+    ['federalTaxNumber' => '19100000000', 'name' => 'João Souza'],
+]); // sequencial, sem paralelismo
+
+$pf = $nfe->naturalPeople->findByTaxNumber($companyId, '31119298000');
+
+if ($pf !== null) {
+    $nfe->naturalPeople->delete($companyId, $pf->id);   // void
+}
+```
+
+## Veja também
+
+- [Pessoas jurídicas](./legal-people.md) — o equivalente PJ.
+- [Consulta de CPF](./natural-person-lookup.md) — valide a situação cadastral na Receita.
+- [Notas de serviço](./service-invoices.md) — use a PF como `borrower`.

--- a/docs/recursos/natural-person-lookup.md
+++ b/docs/recursos/natural-person-lookup.md
@@ -1,0 +1,58 @@
+---
+title: Consulta de CPF (naturalPersonLookup) no SDK PHP da NFE.io
+sidebar_label: Consulta de CPF
+sidebar_position: 12
+slug: consulta-cpf
+description: Consulte a situação cadastral de um CPF na Receita Federal com $nfe->naturalPersonLookup->getStatus, informando CPF e data de nascimento.
+---
+
+# Consulta de CPF (`naturalPersonLookup`)
+
+`$nfe->naturalPersonLookup` consulta a **situação cadastral** de uma pessoa
+física na Receita Federal. Recurso **global**, servido por
+`naturalperson.api.nfe.io`.
+
+:::note Família de dados — usa `dataApiKey`
+Com fallback para `apiKey`. Veja [Configuração](../configuration.md).
+:::
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `getStatus($cpf, $birthDate)` | Situação cadastral do CPF. | `NaturalPersonStatus` |
+
+A consulta de CPF exige **duas credenciais do titular**: o CPF e a data de
+nascimento.
+
+## Consultar a situação cadastral
+
+```php
+$status = $nfe->naturalPersonLookup->getStatus('311.192.980-00', '1990-05-20');
+```
+
+`$birthDate` aceita uma string ISO (`YYYY-MM-DD`) ou um `\DateTimeImmutable`:
+
+```php
+$status = $nfe->naturalPersonLookup->getStatus(
+    '31119298000',
+    new \DateTimeImmutable('1990-05-20'),
+);
+```
+
+:::warning Validação local da data
+Datas malformadas ou fora de faixa lançam
+`Nfe\Exception\InvalidRequestException` **antes** de qualquer requisição. O CPF
+também é validado quanto ao formato.
+:::
+
+:::note Dado sensível
+CPF e data de nascimento são dados pessoais — trate o resultado conforme a
+LGPD: não logue o payload bruto e restrinja o acesso ao propósito da consulta.
+:::
+
+## Veja também
+
+- [Consulta de CNPJ](./legal-entity-lookup.md) — o equivalente PJ.
+- [Pessoas físicas](./natural-people.md) — cadastro de tomadores PF.
+- [Configuração](../configuration.md) — modelo de duas chaves.

--- a/docs/recursos/product-invoice-query.md
+++ b/docs/recursos/product-invoice-query.md
@@ -1,0 +1,61 @@
+---
+title: Consulta de NF-e por chave de acesso (productInvoiceQuery)
+sidebar_label: Consulta de NF-e
+sidebar_position: 16
+slug: consulta-nfe
+description: Consulte qualquer NF-e pela chave de acesso de 44 dígitos, liste eventos e baixe DANFE/XML com $nfe->productInvoiceQuery no host nfe.api.nfe.io.
+---
+
+# Consulta de NF-e (`productInvoiceQuery`)
+
+`$nfe->productInvoiceQuery` consulta **qualquer NF-e** (emitida por você ou por
+terceiros) pela **chave de acesso de 44 dígitos**. Recurso **global** (não
+recebe `$companyId`), servido por `nfe.api.nfe.io`.
+
+:::note Consulta ≠ emissão
+Este recurso é distinto de [`productInvoices`](./product-invoices.md) (emissão).
+É família de **dados** (`nfe-query`): usa a `dataApiKey` com fallback para
+`apiKey`. Veja [Configuração](../configuration.md).
+:::
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `retrieve($accessKey)` | Consulta a NF-e pela chave de acesso. | `ProductInvoiceDetails` |
+| `downloadPdf($accessKey)` | DANFE em PDF. | `string` (bytes crus) |
+| `downloadXml($accessKey)` | XML autorizado. | `string` |
+| `listEvents($accessKey)` | Eventos fiscais da nota. | `array` |
+
+## Consultar uma NF-e
+
+```php
+$accessKey = '35260111222333000181550010000012341000012349'; // 44 dígitos
+
+$detalhes = $nfe->productInvoiceQuery->retrieve($accessKey);
+```
+
+:::warning Chave de acesso é validada localmente
+A chave precisa ter **44 dígitos numéricos** — um valor fora do formato lança
+`Nfe\Exception\InvalidRequestException` antes de qualquer requisição.
+:::
+
+## Baixar DANFE e XML
+
+```php
+file_put_contents('danfe.pdf', $nfe->productInvoiceQuery->downloadPdf($accessKey));
+file_put_contents('nfe.xml', $nfe->productInvoiceQuery->downloadXml($accessKey));
+```
+
+## Listar os eventos fiscais
+
+```php
+$eventos = $nfe->productInvoiceQuery->listEvents($accessKey);
+// cancelamentos, cartas de correção, manifestações...
+```
+
+## Veja também
+
+- [Consulta de cupons (CFe-SAT/NFC-e)](./consumer-invoice-query.md) — o equivalente para cupons.
+- [Notas de entrada](./inbound-product-invoices.md) — captura automática de NF-e contra o seu CNPJ.
+- [Downloads](../downloads.md) — o contrato de bytes crus.

--- a/docs/recursos/product-invoices.md
+++ b/docs/recursos/product-invoices.md
@@ -1,0 +1,161 @@
+---
+title: Notas fiscais de produto (NF-e)
+sidebar_label: Notas de produto
+sidebar_position: 2
+slug: notas-fiscais-de-produto
+description: Emita NF-e modelo 55 com $nfe->productInvoices no host api.nfse.io /v2 — listagem por cursor com environment obrigatório, carta de correção, inutilização e downloads em bytes.
+---
+
+# Notas fiscais de produto (NF-e)
+
+`$nfe->productInvoices` cobre o ciclo de vida completo da NF-e (modelo 55) no
+host `api.nfse.io`, sob `/v2`: emissão, listagem por cursor, consulta,
+cancelamento, carta de correção (CC-e), inutilização e downloads.
+
+A emissão segue o **contrato 202 discriminado** (assíncrona; conclusão via
+webhook): `create()` / `createWithStateTax()` devolvem
+`ProductInvoicePending|ProductInvoiceIssued`. Não há `createAndWait()` nem
+`createBatch()`.
+
+:::tip Prefira webhooks para NF-e
+Diferente da NFS-e, `productInvoices` **não** tem `getStatus()`. A conclusão da
+emissão é orientada a webhook — configure um alvo em
+[Webhooks](../webhooks.md). Se precisar de polling, use `retrieve()` e leia o
+campo de fluxo do DTO.
+:::
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `create($companyId, $data)` | Emite a NF-e. | `ProductInvoicePending\|ProductInvoiceIssued` |
+| `createWithStateTax($companyId, $stateTaxId, $data)` | Emite vinculada a uma inscrição estadual. | `ProductInvoicePending\|ProductInvoiceIssued` |
+| `list($companyId, $options)` | Lista por cursor; `$options` **obrigatório** com `environment`. | `ListResponse` |
+| `retrieve($companyId, $invoiceId)` | Consulta por id. | `ProductInvoice` |
+| `cancel($companyId, $invoiceId, $reason = null)` | Cancela; `reason` opcional vai na query. | `ProductInvoice` |
+| `listItems($companyId, $invoiceId)` | Lista os itens da nota. | `array` (arrays crus) |
+| `listEvents($companyId, $invoiceId)` | Lista os eventos fiscais. | `array` (arrays crus) |
+| `downloadPdf($companyId, $invoiceId)` | DANFE PDF. | `string` (bytes crus) |
+| `downloadXml($companyId, $invoiceId)` | XML autorizado. | `string` |
+| `downloadRejectionXml($companyId, $invoiceId)` | XML de rejeição. | `string` |
+| `downloadEpecXml($companyId, $invoiceId)` | XML de contingência EPEC. | `string` |
+| `sendCorrectionLetter($companyId, $invoiceId, $correction)` | Emite CC-e. | `array` |
+| `downloadCorrectionLetterPdf($companyId, $invoiceId)` | PDF da CC-e. | `string` |
+| `downloadCorrectionLetterXml($companyId, $invoiceId)` | XML da CC-e. | `string` |
+| `disable($companyId, $invoiceId, $data)` | Inutiliza uma nota específica. | `array` |
+| `disableRange($companyId, $data)` | Inutiliza uma faixa de numeração. | `array` |
+
+## Emitir uma NF-e
+
+```php
+use Nfe\Response\Pending;
+
+$result = $nfe->productInvoices->create('55df4dc6b6cd9007e4f13ee8', [
+    'buyer' => [
+        'federalTaxNumber' => 11111111111111,
+        'name'             => 'Cliente Exemplo LTDA',
+    ],
+    'items' => [
+        ['code' => '001', 'description' => 'Produto X', 'quantity' => 1, 'unitAmount' => 99.9],
+    ],
+]);
+
+if ($result instanceof Pending) {
+    $result->invoiceId();   // acompanhe via webhook ou retrieve()
+} else {
+    $result->resource();    // Nfe\ProductInvoice
+}
+```
+
+Para emitir vinculada a uma inscrição estadual específica (veja
+[Inscrições estaduais](./state-taxes.md)):
+
+```php
+$result = $nfe->productInvoices->createWithStateTax($companyId, $stateTaxId, $data);
+```
+
+## Listar com `environment` obrigatório
+
+A paginação é por cursor e o argumento `$options` é **obrigatório** — precisa
+conter `environment` (string `"Production"` ou `"Test"`).
+
+```php
+$pagina = $nfe->productInvoices->list($companyId, [
+    'environment' => 'Production',
+    'limit'       => 50,
+]);
+
+foreach ($pagina->data as $nf) {
+    echo $nf->id, PHP_EOL;
+}
+
+// Próxima página:
+$proxima = $nfe->productInvoices->list($companyId, [
+    'environment'   => 'Production',
+    'startingAfter' => $pagina->page->startingAfter,
+    'limit'         => 50,
+]);
+```
+
+:::note `environment` é o ambiente da SEFAZ
+Este `environment` (string) é um parâmetro real de ambiente da SEFAZ, separado
+da configuração produção/teste da conta (definida em
+[app.nfe.io](https://app.nfe.io)). O enum `Nfe\Environment` do cliente está
+reservado para uso futuro.
+:::
+
+## Baixar arquivos (bytes crus)
+
+Todos os downloads devolvem a `string` de bytes — grave com
+`file_put_contents()`:
+
+```php
+file_put_contents('danfe.pdf', $nfe->productInvoices->downloadPdf($companyId, $invoiceId));
+file_put_contents('nfe.xml', $nfe->productInvoices->downloadXml($companyId, $invoiceId));
+```
+
+## Carta de correção (CC-e)
+
+Um texto vazio ou só com espaços lança
+`Nfe\Exception\InvalidRequestException` antes de qualquer HTTP.
+
+```php
+$nfe->productInvoices->sendCorrectionLetter(
+    $companyId,
+    $invoiceId,
+    'Correção do endereço de entrega do destinatário',
+);
+
+file_put_contents(
+    'cce.pdf',
+    $nfe->productInvoices->downloadCorrectionLetterPdf($companyId, $invoiceId),
+);
+```
+
+## Cancelar e inutilizar
+
+```php
+// Cancelamento (com justificativa opcional na query):
+$nfe->productInvoices->cancel($companyId, $invoiceId, 'Pedido cancelado pelo cliente');
+
+// Inutilizar uma nota específica:
+$nfe->productInvoices->disable($companyId, $invoiceId, [
+    'reason' => 'Numeração não utilizada',
+]);
+
+// Inutilizar uma faixa de numeração:
+$nfe->productInvoices->disableRange($companyId, [
+    'environment' => 'Production',
+    'serie'       => 1,
+    'state'       => 'SP',
+    'beginNumber' => 100,
+    'lastNumber'  => 110,
+    'reason'      => 'Falha de impressão',
+]);
+```
+
+## Próximos passos
+
+- [Notas de consumidor (NFC-e)](./consumer-invoices.md) — modelo 65.
+- [Inscrições estaduais](./state-taxes.md) — pré-requisito para emitir NF-e.
+- [Paginação](../pagination.md) — cursor vs. página.

--- a/docs/recursos/service-invoices.md
+++ b/docs/recursos/service-invoices.md
@@ -1,0 +1,125 @@
+---
+title: Notas fiscais de serviço (NFS-e)
+sidebar_label: Notas de serviço
+sidebar_position: 1
+slug: notas-fiscais-de-servico
+description: Emita, liste, consulte, cancele e baixe NFS-e com $nfe->serviceInvoices no host api.nfe.io /v1, tratando o retorno discriminado 202 com instanceof.
+---
+
+# Notas fiscais de serviço (NFS-e)
+
+`$nfe->serviceInvoices` é o recurso canônico de emissão da plataforma. Ele fala
+com o host `api.nfe.io` no caminho `/v1` e cobre todo o ciclo de vida da NFS-e:
+emissão assíncrona, listagem paginada, consulta, cancelamento, envio por e-mail
+e download de PDF/XML.
+
+A emissão segue o **contrato 202 discriminado**: `create()` devolve um union
+type nativo, e você acompanha o processamento com `getStatus()` até um estado
+terminal. Não existe `createAndWait()` nem `createBatch()` na `v3.0`.
+
+:::note Host e versão
+Todas as URLs efetivas ficam sob `https://api.nfe.io/v1/...`. Este é o único
+recurso de nota que usa o host `api.nfe.io`; os demais usam `api.nfse.io`.
+:::
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `create($companyId, $data)` | Emite a NFS-e. | `ServiceInvoicePending\|ServiceInvoiceIssued` |
+| `list($companyId, $options = [])` | Lista paginada (page-style, `pageIndex` 1-based) com filtros de data. | `ListResponse` |
+| `retrieve($companyId, $invoiceId)` | Consulta uma NFS-e por id. | `ServiceInvoice` |
+| `cancel($companyId, $invoiceId)` | Cancela (síncrono) e devolve o modelo atualizado. | `ServiceInvoice` |
+| `sendEmail($companyId, $invoiceId)` | Reenvia a nota por e-mail ao tomador. | `array` (típico: `{sent, message}`) |
+| `downloadPdf($companyId, $invoiceId)` | PDF da nota. | `string` (bytes crus) |
+| `downloadXml($companyId, $invoiceId)` | XML da nota. | `string` (bytes crus) |
+| `getStatus($companyId, $invoiceId)` | Snapshot leve de status. | `array` (`flowStatus`, `flowMessage`, …) |
+
+As opções de `list()` incluem `pageIndex` (**1-based**), `pageCount`,
+`issuedBegin` e `issuedEnd`. Todo método aceita ainda um
+`Nfe\Http\RequestOptions` opcional como último argumento.
+
+:::warning Validação fail-fast
+Todo método valida `companyId` e `invoiceId` **antes** de qualquer chamada HTTP.
+Ids vazios ou em branco lançam `Nfe\Exception\InvalidRequestException` sem
+tráfego de rede.
+:::
+
+## Emitir uma NFS-e e tratar o retorno discriminado
+
+`create()` devolve `ServiceInvoicePending` (HTTP 202, enfileirada) ou
+`ServiceInvoiceIssued` (HTTP 201, já materializada). Distinga com `instanceof`
+contra as interfaces marcadoras `Nfe\Response\Pending` / `Nfe\Response\Issued`.
+
+```php
+use Nfe\Response\Pending;
+
+$result = $nfe->serviceInvoices->create('55df4dc6b6cd9007e4f13ee8', [
+    'cityServiceCode' => '2690',
+    'description'     => 'Manutenção e suporte técnico',
+    'servicesAmount'  => 100.0,
+    'borrower'        => [
+        'federalTaxNumber' => 191,
+        'name'             => 'Banco do Brasil SA',
+    ],
+]);
+
+if ($result instanceof Pending) {
+    $result->invoiceId();   // id para reconsultar enquanto processa
+    $result->location();    // caminho do header Location
+} else {
+    $result->resource();    // Nfe\ServiceInvoice já emitida
+}
+```
+
+## Acompanhar até um estado terminal (polling)
+
+Use `getStatus()` — endpoint leve que devolve `flowStatus`/`flowMessage` — com
+`Nfe\Util\FlowStatus::isTerminal()`:
+
+```php
+use Nfe\Util\FlowStatus;
+
+$companyId = '55df4dc6b6cd9007e4f13ee8';
+$invoiceId = $result instanceof Pending ? $result->invoiceId() : $result->resource()->id;
+
+do {
+    sleep(3);
+    $flow = $nfe->serviceInvoices->getStatus($companyId, $invoiceId)['flowStatus'] ?? '';
+} while (!FlowStatus::isTerminal($flow));
+
+if ($flow === 'Issued') {
+    $invoice = $nfe->serviceInvoices->retrieve($companyId, $invoiceId);
+}
+```
+
+:::warning Terminal ≠ sucesso
+`isTerminal()` também é `true` para `IssueFailed`/`CancelFailed`. Compare o
+status concreto. Veja [Emissão assíncrona e polling](../async-and-polling.md).
+:::
+
+## Baixar PDF e XML (bytes crus)
+
+Os downloads retornam uma `string` com os bytes do arquivo — grave com
+`file_put_contents()`:
+
+```php
+file_put_contents('nfse.pdf', $nfe->serviceInvoices->downloadPdf($companyId, $invoiceId));
+file_put_contents('nfse.xml', $nfe->serviceInvoices->downloadXml($companyId, $invoiceId));
+```
+
+## Cancelar e reenviar por e-mail
+
+```php
+$cancelada = $nfe->serviceInvoices->cancel($companyId, $invoiceId);
+$cancelada->flowStatus;   // "Cancelled"
+
+$envio = $nfe->serviceInvoices->sendEmail($companyId, $invoiceId);
+$envio['sent'] ?? null;   // true/false
+```
+
+## Próximos passos
+
+- [Primeiros passos](../getting-started.md) — instalação e primeira emissão.
+- [Notas de produto (NF-e)](./product-invoices.md) — host `api.nfse.io`, cursor e CC-e.
+- [Webhooks](../webhooks.md) — conclusão por push em vez de polling.

--- a/docs/recursos/state-taxes.md
+++ b/docs/recursos/state-taxes.md
@@ -1,0 +1,80 @@
+---
+title: Inscrições estaduais (stateTaxes) no SDK PHP da NFE.io
+sidebar_label: Inscrições estaduais
+sidebar_position: 15
+slug: inscricoes-estaduais
+description: Gerencie as inscrições estaduais (IE) da empresa emissora com $nfe->stateTaxes — pré-requisito para emitir NF-e/NFC-e, com paginação por cursor e envelope stateTax.
+---
+
+# Inscrições estaduais (`stateTaxes`)
+
+`$nfe->stateTaxes` gerencia as **inscrições estaduais (IE)** de uma empresa
+emissora — pré-requisito para emitir [NF-e](./product-invoices.md) e
+[NFC-e](./consumer-invoices.md). Escopo de **empresa**, host `api.nfse.io`
+(`/v2`), chave principal.
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `list($companyId, $opts = null)` | Lista por cursor. | `ListResponse` |
+| `create($companyId, $data)` | Cadastra uma IE. | `NfeStateTax` |
+| `retrieve($companyId, $stateTaxId)` | Consulta por id. | `NfeStateTax` |
+| `update($companyId, $stateTaxId, $data)` | Atualiza. | `NfeStateTax` |
+| `delete($companyId, $stateTaxId)` | Exclui. | `void` |
+
+:::note Envelope `{ stateTax }` no corpo
+`create()` e `update()` embrulham o corpo como `{ "stateTax": { … } }`
+automaticamente (paridade com o SDK Node) — você passa só o conteúdo interno; a
+resposta volta hidratada sem envelope.
+:::
+
+## Cadastrar uma inscrição estadual
+
+```php
+$ie = $nfe->stateTaxes->create('55df4dc6b6cd9007e4f13ee8', [
+    'code'            => 'SP',
+    'taxNumber'       => '111.111.111.111',
+    'serie'           => 1,
+    'number'          => 1,
+    'environmentType' => 'Production',
+]);
+```
+
+## Listar (cursor) e consultar
+
+```php
+$pagina = $nfe->stateTaxes->list($companyId, ['limit' => 25]);
+
+foreach ($pagina->data as $ie) {
+    echo $ie->code, PHP_EOL;
+}
+
+// Próxima página:
+$proxima = $nfe->stateTaxes->list($companyId, [
+    'startingAfter' => $pagina->page->startingAfter,
+    'limit'         => 25,
+]);
+
+$ie = $nfe->stateTaxes->retrieve($companyId, $stateTaxId);
+```
+
+## Atualizar e excluir
+
+```php
+$nfe->stateTaxes->update($companyId, $stateTaxId, ['serie' => 2]);
+
+$nfe->stateTaxes->delete($companyId, $stateTaxId);   // void
+```
+
+:::tip Emissão vinculada à IE
+Com a IE cadastrada, emita NF-e/NFC-e vinculadas a ela via
+`createWithStateTax($companyId, $stateTaxId, $data)` nos recursos de
+[produto](./product-invoices.md) e [consumidor](./consumer-invoices.md).
+:::
+
+## Veja também
+
+- [Notas de produto (NF-e)](./product-invoices.md) — emissão que depende da IE.
+- [Consulta de CNPJ](./legal-entity-lookup.md) — descubra a IE de terceiros por UF.
+- [Paginação](../pagination.md) — cursor vs. página.

--- a/docs/recursos/tax-calculation.md
+++ b/docs/recursos/tax-calculation.md
@@ -1,0 +1,65 @@
+---
+title: Cálculo de impostos (taxCalculation) no SDK PHP da NFE.io
+sidebar_label: Cálculo de impostos
+sidebar_position: 13
+slug: calculo-de-impostos
+description: Calcule os impostos de uma operação com o motor tributário da NFE.io via $nfe->taxCalculation->calculate, com escopo de tenant e payload em array.
+---
+
+# Cálculo de impostos (`taxCalculation`)
+
+`$nfe->taxCalculation` aciona o **motor tributário** da NFE.io para calcular os
+impostos de uma operação. Escopo de **tenant** (recebe `$tenantId` como primeiro
+argumento), host `api.nfse.io` (`/v2`).
+
+:::note Usa a `apiKey` principal
+Apesar de ser um serviço de consulta, o cálculo de impostos **não** é família de
+dados — sempre usa a chave principal.
+:::
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `calculate($tenantId, $request)` | Calcula os impostos da operação. | `array` (resposta crua) |
+
+Requisição e resposta são arrays associativos sem DTO. Como referência do shape
+esperado, o SDK embarca a classe gerada
+`Nfe\Generated\CalculoImpostosV1\CalculateRequest` — você pode espelhá-la, mas
+não é um tipo obrigatório.
+
+## Calcular os impostos de uma operação
+
+```php
+$resultado = $nfe->taxCalculation->calculate($tenantId, [
+    'operationType' => 'Sale',
+    'issuer'        => ['federalTaxNumber' => 11444555000149, 'state' => 'SP'],
+    'recipient'     => ['federalTaxNumber' => 61365284000104, 'state' => 'RJ'],
+    'items'         => [
+        [
+            'code'       => '001',
+            'ncm'        => '85171231',
+            'quantity'   => 1,
+            'unitAmount' => 1999.90,
+        ],
+    ],
+]);
+
+// A resposta é um array cru com os tributos calculados por item.
+```
+
+:::warning Validação local
+`$tenantId` vazio ou `items` vazio lançam
+`Nfe\Exception\InvalidRequestException` **antes** de qualquer requisição.
+:::
+
+:::tip Combine com os códigos fiscais
+Os valores aceitos em campos de classificação (código de operação, finalidade de
+aquisição, perfis de contribuinte) vêm de [`taxCodes`](./tax-codes.md).
+:::
+
+## Veja também
+
+- [Códigos fiscais](./tax-codes.md) — dados de referência do motor.
+- [Notas de produto (NF-e)](./product-invoices.md) — emissão com os valores calculados.
+- [Tratamento de erros](../errors.md).

--- a/docs/recursos/tax-codes.md
+++ b/docs/recursos/tax-codes.md
@@ -1,0 +1,65 @@
+---
+title: Códigos fiscais (taxCodes) no SDK PHP da NFE.io
+sidebar_label: Códigos fiscais
+sidebar_position: 14
+slug: codigos-fiscais
+description: Liste os dados de referência do motor tributário — códigos de operação, finalidades de aquisição e perfis fiscais — com $nfe->taxCodes, paginação 1-based com máximo de 50 por página.
+---
+
+# Códigos fiscais (`taxCodes`)
+
+`$nfe->taxCodes` expõe os **dados de referência** do motor tributário: códigos
+de operação, finalidades de aquisição e perfis fiscais de emitente e
+destinatário. Recurso **global** (não recebe `$companyId`), host `api.nfse.io`
+(`/v2`), chave principal.
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `listOperationCodes($opts = [])` | Códigos de operação. | `TaxCodePaginatedResponse` |
+| `listAcquisitionPurposes($opts = [])` | Finalidades de aquisição. | `TaxCodePaginatedResponse` |
+| `listIssuerTaxProfiles($opts = [])` | Perfis fiscais de emitente. | `TaxCodePaginatedResponse` |
+| `listRecipientTaxProfiles($opts = [])` | Perfis fiscais de destinatário. | `TaxCodePaginatedResponse` |
+
+As opções de paginação são `pageIndex` (**1-based**, padrão 1) e `pageCount`
+(padrão 50, **máximo 50**).
+
+:::note Tipo de resposta próprio
+Estes métodos retornam `TaxCodePaginatedResponse` — com `items`, `currentPage`,
+`totalPages` e `totalCount` — em vez do `ListResponse` dos demais recursos.
+:::
+
+## Listar códigos de operação
+
+```php
+$pagina = $nfe->taxCodes->listOperationCodes(['pageIndex' => 1, 'pageCount' => 50]);
+
+foreach ($pagina->items as $codigo) {
+    // dados de referência de cada código de operação
+}
+
+// Percorrer todas as páginas:
+for ($i = 1; $i <= $pagina->totalPages; $i++) {
+    $p = $nfe->taxCodes->listOperationCodes(['pageIndex' => $i, 'pageCount' => 50]);
+    // ... $p->items
+}
+```
+
+## Demais catálogos
+
+```php
+$nfe->taxCodes->listAcquisitionPurposes();
+$nfe->taxCodes->listIssuerTaxProfiles();
+$nfe->taxCodes->listRecipientTaxProfiles();
+```
+
+:::tip Cacheie localmente
+São catálogos de referência que mudam raramente — cacheie o resultado na sua
+aplicação em vez de consultar a cada operação.
+:::
+
+## Veja também
+
+- [Cálculo de impostos](./tax-calculation.md) — onde esses códigos são usados.
+- [Paginação](../pagination.md) — as formas de paginação do SDK.

--- a/docs/recursos/transportation-invoices.md
+++ b/docs/recursos/transportation-invoices.md
@@ -1,0 +1,83 @@
+---
+title: Conhecimentos de transporte (CT-e)
+sidebar_label: CT-e (entrada)
+sidebar_position: 4
+slug: conhecimentos-de-transporte
+description: Habilite o recebimento de CT-e de entrada e consulte documentos e eventos por chave de acesso com $nfe->transportationInvoices no host api.nfse.io /v2.
+---
+
+# Conhecimentos de transporte (CT-e)
+
+`$nfe->transportationInvoices` gerencia o recebimento de **CT-e de entrada**
+(conhecimentos de transporte emitidos contra a sua empresa) no host
+`api.nfse.io`, sob `/v2`: habilitação/desabilitação da captura, consulta de
+documentos por chave de acesso e download de XMLs.
+
+:::note Recurso de entrada, não de emissão
+Este recurso **consome** CT-e emitidos por terceiros. Ele usa a `apiKey`
+principal (não é família de dados).
+:::
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `enable($companyId, $data)` | Habilita o recebimento de CT-e para a empresa. | `InboundSettings` |
+| `disable($companyId)` | Desabilita o recebimento. | `InboundSettings` |
+| `getSettings($companyId)` | Configurações atuais de captura. | `InboundSettings` |
+| `retrieve($companyId, $accessKey)` | Consulta um CT-e por chave de acesso (44 dígitos). | `array` |
+| `downloadXml($companyId, $accessKey)` | XML do CT-e. | `string` (bytes crus) |
+| `getEvent($companyId, $accessKey, $eventKey)` | Consulta um evento do CT-e. | `array` |
+| `downloadEventXml($companyId, $accessKey, $eventKey)` | XML de um evento. | `string` |
+
+## Habilitar o recebimento
+
+```php
+$settings = $nfe->transportationInvoices->enable('55df4dc6b6cd9007e4f13ee8', [
+    'startFromDate' => '2026-01-01',
+]);
+
+// Conferir depois:
+$settings = $nfe->transportationInvoices->getSettings($companyId);
+```
+
+## Consultar um CT-e e baixar o XML
+
+```php
+$accessKey = '35260111222333000181570010000012341000012349';
+
+$cte = $nfe->transportationInvoices->retrieve($companyId, $accessKey);
+
+file_put_contents(
+    'cte.xml',
+    $nfe->transportationInvoices->downloadXml($companyId, $accessKey),
+);
+```
+
+:::warning Chave de acesso é validada localmente
+A chave de acesso precisa ter **44 dígitos**; um valor com tamanho errado lança
+`Nfe\Exception\InvalidRequestException` antes de qualquer requisição.
+:::
+
+## Eventos do CT-e
+
+```php
+$evento = $nfe->transportationInvoices->getEvent($companyId, $accessKey, $eventKey);
+
+file_put_contents(
+    'cte-evento.xml',
+    $nfe->transportationInvoices->downloadEventXml($companyId, $accessKey, $eventKey),
+);
+```
+
+## Desabilitar
+
+```php
+$nfe->transportationInvoices->disable($companyId);
+```
+
+## Próximos passos
+
+- [Notas de entrada (NF-e)](./inbound-product-invoices.md) — o equivalente para NF-e recebidas.
+- [Webhooks](../webhooks.md) — receba os documentos capturados por push.
+- [Downloads](../downloads.md) — o contrato de bytes crus.

--- a/docs/recursos/webhooks.md
+++ b/docs/recursos/webhooks.md
@@ -1,0 +1,72 @@
+---
+title: Webhooks (CRUD) no SDK PHP da NFE.io
+sidebar_label: Webhooks (CRUD)
+sidebar_position: 9
+slug: webhooks
+description: Crie, liste, atualize, teste e exclua alvos de entrega de webhook por empresa com $nfe->webhooks — a verificação de assinatura fica na classe estática Nfe\Webhook.
+---
+
+# Webhooks (`webhooks`)
+
+`$nfe->webhooks` gerencia os **alvos de entrega** de webhook por empresa —
+URLs que a NFE.io chama quando eventos acontecem (nota emitida, cancelada,
+documento de entrada recebido…). Escopo de **empresa**, família `main`
+(`api.nfe.io` `/v1`), chave principal.
+
+:::warning CRUD aqui, verificação lá
+Este recurso é só o **CRUD** dos alvos. A verificação de assinatura das
+entregas (`HMAC-SHA1`, header `X-Hub-Signature`) fica na classe **estática**
+`Nfe\Webhook` — veja o guia de [Webhooks](../webhooks.md).
+:::
+
+## Métodos
+
+| Método | Descrição | Retorno |
+|---|---|---|
+| `list($companyId)` | Lista os webhooks da empresa. | `ListResponse` |
+| `create($companyId, $data)` | Registra um novo alvo. | `Webhook` |
+| `retrieve($companyId, $webhookId)` | Consulta por id. | `Webhook` |
+| `update($companyId, $webhookId, $data)` | Atualiza URL/eventos/segredo. | `Webhook` |
+| `delete($companyId, $webhookId)` | Exclui. | `void` |
+| `test($companyId, $webhookId)` | Dispara uma entrega de teste. | `array` |
+| `getAvailableEvents()` | Lista de eventos suportados (hard-coded, sem HTTP). | `array` |
+
+## Exemplos
+
+### Registrar um alvo de entrega
+
+```php
+$webhook = $nfe->webhooks->create('55df4dc6b6cd9007e4f13ee8', [
+    'url'    => 'https://minha-app.example.com/webhooks/nfe',
+    'secret' => $_ENV['NFE_WEBHOOK_SECRET'],
+]);
+```
+
+Guarde o mesmo `secret` na sua aplicação — ele é o HMAC usado para assinar cada
+entrega, e você o passa a `Nfe\Webhook::verifySignature()` no seu endpoint.
+
+### Testar, atualizar e excluir
+
+```php
+// Entrega de teste para validar o endpoint de ponta a ponta:
+$nfe->webhooks->test($companyId, $webhook->id);
+
+$nfe->webhooks->update($companyId, $webhook->id, [
+    'url' => 'https://minha-app.example.com/webhooks/nfe/v2',
+]);
+
+$nfe->webhooks->delete($companyId, $webhook->id);   // void
+```
+
+### Eventos disponíveis
+
+```php
+// Lista embutida no SDK — não faz chamada de rede:
+$eventos = $nfe->webhooks->getAvailableEvents();
+```
+
+## Veja também
+
+- [Guia de webhooks](../webhooks.md) — verificação de assinatura e idempotência.
+- [Emissão assíncrona e polling](../async-and-polling.md) — push vs. polling.
+- [Empresas](./companies.md) — o escopo dos alvos.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,148 @@
+---
+title: Verificação de webhooks da NFE.io em PHP
+sidebar_label: Webhooks
+sidebar_position: 5
+slug: webhooks
+description: Verifique a assinatura HMAC-SHA1 das entregas de webhook da NFE.io com a classe estática Nfe\Webhook, leia o corpo cru antes de parsear o JSON e torne seus handlers idempotentes.
+---
+
+# Webhooks
+
+Em vez de fazer polling até um estado terminal, você pode receber a conclusão da
+emissão por push. A NFE.io entrega um webhook; seu endpoint **verifica a
+assinatura** e reage ao evento. Este guia cobre a verificação canônica via
+`Nfe\Webhook`.
+
+## Como a NFE.io assina as entregas
+
+Cada entrega traz o cabeçalho `X-Hub-Signature` com um HMAC-SHA1 calculado sobre
+os **bytes exatos** do corpo da requisição, no formato `sha1=<40 hex>`:
+
+```text
+X-Hub-Signature: sha1=BCD17C02B9E3B40A18E745E7E04247E4AD2DD935
+```
+
+## A API de verificação
+
+A verificação vive na classe **estática** `Nfe\Webhook` — ela não precisa de um
+`Nfe\Client`, não lê configuração e não faz nenhuma chamada de rede.
+
+:::warning `Nfe\Webhook` ≠ `$nfe->webhooks`
+`$nfe->webhooks` é o **CRUD** de webhooks (criar/listar/atualizar alvos de
+entrega — veja o [cookbook](./recursos/webhooks.md)). A verificação de
+assinatura é a classe estática `Nfe\Webhook`; não procure
+`$nfe->webhooks->verifySignature()` — não existe.
+:::
+
+```php
+use Nfe\Webhook;
+
+$ok = Webhook::verifySignature(
+    payload: file_get_contents('php://input'),
+    signature: $_SERVER['HTTP_X_HUB_SIGNATURE'] ?? '',
+    secret: $_ENV['NFE_WEBHOOK_SECRET'],
+);
+```
+
+### `verifySignature(): bool`
+
+Retorna `true` **somente** quando o HMAC-SHA1 confere exatamente. A comparação é
+feita em tempo constante (`hash_equals()`), o prefixo `sha1=` é opcional (hex
+puro também é aceito) e a comparação de algoritmo/hex é case-insensitive. Um
+quarto argumento `$algo` (padrão `'sha1'`) permite outro algoritmo — um header
+`sha256=` contra `$algo = 'sha1'` é **rejeitado** (sem downgrade).
+
+:::tip Nunca lança exceção
+`verifySignature()` **nunca** lança. Entrada ausente, malformada, com algoritmo
+errado ou conteúdo não hexadecimal resulta em `false`.
+:::
+
+### `constructEvent(): Nfe\WebhookEvent`
+
+Quando você quer não só validar, mas também desempacotar o evento, use
+`constructEvent()`. Ele verifica primeiro; em caso de falha de assinatura **ou**
+de JSON inválido, lança `Nfe\Exception\SignatureVerificationException`.
+
+```php
+use Nfe\Webhook;
+
+$event = Webhook::constructEvent(
+    payload: $raw,
+    sigHeader: $signature,
+    secret: $_ENV['NFE_WEBHOOK_SECRET'],
+);
+
+$event->type;       // ex.: "invoice.issued" (a chave `action` do envelope v2)
+$event->data;       // array com o payload (a chave `payload` do envelope)
+$event->id;         // id estável para deduplicação, ou null
+$event->createdAt;  // timestamp ISO-8601 da entrega, ou null
+```
+
+`Nfe\WebhookEvent` é um objeto de valor imutável (`final readonly`). Se o corpo
+carrega o envelope v2 `{ action, payload }`, ele é desembrulhado: `type` recebe
+`action` e `data` recebe o `payload` interno. Sem envelope, o helper procura um
+campo `type`/`event_type`/`action` no nível raiz.
+
+## Leia o corpo CRU antes de parsear o JSON
+
+A NFE.io assina os bytes que entregou. Leia o corpo cru **antes** de qualquer
+parsing de JSON e passe esses bytes ao verificador.
+
+:::warning Não re-serialize o payload
+Nunca passe um array já parseado e re-serializado (por exemplo
+`json_encode($payload)`). A ordem das chaves e os espaços em branco vão diferir
+dos bytes assinados, e a verificação falhará de forma imprevisível. Sempre use o
+corpo cru — `file_get_contents('php://input')` (ou `$request->getContent()` no
+Laravel/Symfony).
+:::
+
+## Exemplo: endpoint em PHP puro
+
+```php
+<?php
+
+use Nfe\Exception\SignatureVerificationException;
+use Nfe\Webhook;
+
+require __DIR__ . '/vendor/autoload.php';
+
+$raw       = file_get_contents('php://input');
+$signature = $_SERVER['HTTP_X_HUB_SIGNATURE'] ?? '';
+
+try {
+    $event = Webhook::constructEvent($raw, $signature, $_ENV['NFE_WEBHOOK_SECRET']);
+} catch (SignatureVerificationException) {
+    http_response_code(401);
+    exit;
+}
+
+// Dedupe pelo id do evento/nota antes de aplicar efeitos colaterais.
+processarEventoIdempotente($event->type, $event->data, $event->id);
+
+http_response_code(200);
+```
+
+:::note No Laravel
+Use `$request->getContent()` como corpo cru e
+`$request->header('X-Hub-Signature')` como assinatura, e **exclua a rota do
+middleware de CSRF** (webhooks não têm token CSRF).
+:::
+
+## Validade não é frescor — handlers devem ser idempotentes
+
+A NFE.io **não** envia primitiva de anti-replay: as entregas trazem apenas o
+HMAC-SHA1 sobre o corpo, sem timestamp e sem nonce. Uma assinatura válida prova
+**autenticidade**, mas não **frescor** — uma entrega reproduzida (replay)
+carrega uma assinatura perfeitamente válida.
+
+:::warning Sempre dedupe
+Trate seus handlers como **idempotentes** e faça **deduplicação pelo
+`$event->id`** (id do evento ou da nota). Processar a mesma entrega duas vezes
+não pode gerar efeitos colaterais duplicados.
+:::
+
+## Próximos passos
+
+- [Cookbook de webhooks](./recursos/webhooks.md) — CRUD dos alvos de entrega.
+- [Emissão assíncrona e polling](./async-and-polling.md) — polling como alternativa ao push.
+- [Tratamento de erros](./errors.md) — `SignatureVerificationException` na hierarquia.


### PR DESCRIPTION
## Summary
- Adiciona um conjunto completo de guias em `docs/` (instalação, configuração, emissão assíncrona/polling, tratamento de erros, webhooks, paginação, downloads e roteamento multi-host).
- Adiciona `docs/recursos/` com um exemplo prático por recurso do cliente (os 17 recursos: notas, entidades, lookups, impostos).
- Conteúdo em paridade estrutural com os guias equivalentes dos outros SDKs da NFE.io, verificado assinatura por assinatura contra o código-fonte atual (`src/`) — sem herdar detalhes de outros SDKs que não se aplicam ao PHP (ex.: sem RTC, downloads sempre em bytes, sem fallback de env vars).
- Pronto para reaproveitamento externo sem necessidade de edição adicional.

## Test plan
- [x] Revisão de conteúdo técnico (assinaturas de método, exemplos de código)
- [x] Conferir links relativos entre os arquivos
- [x] Validar front-matter (slugs, sidebar_position) sem conflito de posição