### PR TITLE
ci: roda o workflow CI em master (não só na branch v3 legada)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [v3]
+    branches: [master, v3]
   pull_request:
-    branches: [v3]
+    branches: [master, v3]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problema

Desde `45aa6e8` ("master passa a ser a linha canônica v3+", GA v3.0.0), o `.github/workflows/ci.yml` continuou disparando **apenas** na branch `v3`:

```yaml
on:
  push:        { branches: [v3] }
  pull_request:{ branches: [v3] }
```

Efeito: **nenhum PR contra `master` roda o CI funcional** (matriz PHP 8.2/8.3/8.4 + PHPStan + php-cs-fixer + `generate:check`). Só o CodeQL roda. Confirmado no **#21** (release v3.1.0) e no **#23** (retry/idempotência) — ambos mergearam/estão sem o gate funcional do CI.

## Correção

Adiciona `master` aos gatilhos `push` e `pull_request`, mantendo `v3` (a branch ainda existe no remoto, congelada em v3.0.0 — remoção fica para depois, se for o caso). Mudança **não-destrutiva** e apenas de gatilho; não introduz uso de input não confiável em `run:`/`ref:`.

## Notas

- Este PR provavelmente **também** só verá o CodeQL: eventos `pull_request` são filtrados pela config da branch base (`master`), que ainda tem `[v3]` até este merge. O efeito passa a valer para PRs futuros e para o CI pós-merge em `master`.
- Isolado de propósito (branch a partir de `master`, sem os commits do #23).