### PR TITLE
fix(tests): webhook integration usa o envelope v2 (data era o corpo todo)

### DIFF
--- a/tests/Integration/WebhookSignatureIntegrationTest.php
+++ b/tests/Integration/WebhookSignatureIntegrationTest.php
@@ -24,12 +24,14 @@ final class WebhookSignatureIntegrationTest extends IntegrationTestCase
         $this->secret = $this->requireEnv('NFE_SDK_E2E_WEBHOOK_SECRET');
     }
 
-    public function test_constructEvent_aceita_payload_assinado_corretamente(): void
+    public function test_constructEvent_aceita_envelope_v2_assinado_corretamente(): void
     {
+        // Envelope v2 real da NFE.io: { action, payload } — `data` é o payload
+        // aninhado (não o corpo inteiro).
         $payload = json_encode([
-            'type' => 'invoice.issued',
-            'data' => ['id' => 'inv-123', 'flowStatus' => 'Issued'],
-            'id'   => 'evt-001',
+            'action'    => 'service_invoice.issued_successfully',
+            'payload'   => ['id' => 'inv-123', 'flowStatus' => 'Issued'],
+            'id'        => 'evt-001',
             'createdAt' => '2026-01-01T00:00:00Z',
         ], JSON_THROW_ON_ERROR);
 
@@ -37,14 +39,34 @@ final class WebhookSignatureIntegrationTest extends IntegrationTestCase
 
         $event = Webhook::constructEvent(payload: $payload, sigHeader: $sig, secret: $this->secret);
 
-        $this->assertSame('invoice.issued', $event->type);
+        $this->assertSame('service_invoice.issued_successfully', $event->type);
         $this->assertSame('evt-001', $event->id);
         $this->assertSame('inv-123', $event->data['id']);
+        $this->assertSame('Issued', $event->data['flowStatus']);
+    }
+
+    public function test_constructEvent_payload_flat_usa_o_corpo_todo_como_data(): void
+    {
+        // Sem envelope v2 (`action`/`payload`), o helper cai no fallback flat:
+        // `data` passa a ser o corpo decodificado inteiro, e `type` vem de
+        // type/event_type/action. Este teste pina esse contrato.
+        $payload = json_encode([
+            'type' => 'service_invoice.issued_successfully',
+            'id'   => 'inv-999',
+        ], JSON_THROW_ON_ERROR);
+
+        $sig = 'sha1=' . hash_hmac('sha1', $payload, $this->secret);
+
+        $event = Webhook::constructEvent(payload: $payload, sigHeader: $sig, secret: $this->secret);
+
+        $this->assertSame('service_invoice.issued_successfully', $event->type);
+        $this->assertSame('inv-999', $event->data['id']); // data = corpo inteiro
+        $this->assertSame('inv-999', $event->id);
     }
 
     public function test_constructEvent_recusa_assinatura_invalida(): void
     {
-        $payload = '{"type":"invoice.issued"}';
+        $payload = '{"action":"service_invoice.issued_successfully","payload":{}}';
         $sig = 'sha1=' . hash_hmac('sha1', $payload, 'wrong-secret');
 
         $this->expectException(SignatureVerificationException::class);


### PR DESCRIPTION
## Problema

A `integration.yml` (opt-in, manual) falhava em `WebhookSignatureIntegrationTest`:

```
assertSame('inv-123', $event->data['id'])  →  actual: 'evt-001'
```

O teste montava um payload **flat** (`{type, data:{id:'inv-123'}, id:'evt-001'}`) e esperava semântica de "data aninhado". Mas para payload flat o `Webhook::constructEvent` (corretamente) define `data = corpo decodificado inteiro`, então `data['id']` = `'evt-001'` (o id de topo), não `'inv-123'`.

**Era bug do teste, não do código.** A semântica de `data` aninhado só existe no **envelope v2** (`{action, payload}`) — o contrato real da API desde `fix-account-webhooks-contract` (#21). E é **independente** do PR #26 (`expand-service-invoice-dto`): `constructEvent` monta `WebhookEvent` direto, sem passar por `hydrate()`.

## Correção

- O teste principal passa a usar o **envelope v2** → `data` é o `payload` aninhado; as asserções `type`/`id`/`data['id']`/`data['flowStatus']` voltam a passar e testam o contrato real.
- **Novo teste** pina o **fallback flat** (`data` = corpo inteiro) — documenta os dois caminhos do `constructEvent`.
- Event type atualizado para um id real (`service_invoice.issued_successfully`; os `invoice.*` não existem na API).

## Verificação

- Teste rodado localmente com env dummy (roundtrip HMAC é determinístico, não chama API): **3 passed**.
- CS e PHPStan limpos.
- ⚠️ A `ci.yml` deste PR **não** roda a suíte de integração (gated por `NFE_SDK_E2E`, só na `integration.yml` manual). Após o merge, re-rodar a `integration.yml` para confirmar em CI — deve passar (a outra falha, `CompaniesIntegrationTest`, é config de secret `NFE_SDK_E2E_COMPANY_ID` / quirk do endpoint, tratada à parte).