### PR TITLE
chore(release): corta v3.3.1 (Version.php)

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -12,5 +12,5 @@ namespace Nfe;
  */
 final class Version
 {
-    public const CURRENT = '3.3.0';
+    public const CURRENT = '3.3.1';
 }


### PR DESCRIPTION
Complemento do #29: o `release.yml` confere `src/Version.php` contra a tag e a primeira tentativa de tag falhou porque só o CHANGELOG tinha sido versionado. A tag `v3.3.1` original foi removida (nenhum release chegou a ser publicado) e será recriada sobre o merge deste PR.